### PR TITLE
fix(runtime): stop the system event actor last — clean shutdown emits zero dead letters

### DIFF
--- a/packages/actor-core-runtime/src/actor-system-impl.ts
+++ b/packages/actor-core-runtime/src/actor-system-impl.ts
@@ -526,9 +526,15 @@ export class ActorSystemImpl implements ActorSystem {
     // Execute shutdown handlers
     const shutdownPromises = Array.from(this.shutdownHandlers).map((handler) => handler());
 
-    // Stop all actors gracefully
+    // Stop all actors gracefully — except the system event actor, which must
+    // outlive its peers so their actorStopping/actorStopped emissions still
+    // have a live mailbox to land in (otherwise every stop dead-letters).
+    const systemEventPath = this.systemEventActorAddress?.path;
     const stopPromises: Promise<void>[] = [];
     for (const [path, _behavior] of Array.from(this.actors)) {
+      if (path === systemEventPath) {
+        continue;
+      }
       const actor = await this.lookup(path);
       if (actor) {
         stopPromises.push(this.stopActor(actor));
@@ -551,6 +557,16 @@ export class ActorSystemImpl implements ActorSystem {
       log.error('Error during shutdown', { error });
     }
 
+    // Emit the final event while the system event actor is still alive, then
+    // stop it last — after this point no actor remains to emit about.
+    await this.emitSystemEvent({ eventType: 'stopped', timestamp: Date.now() });
+    if (systemEventPath) {
+      const systemEventActor = await this.lookup(systemEventPath);
+      if (systemEventActor) {
+        await this.stopActor(systemEventActor);
+      }
+    }
+
     // Stop the system timeout manager
     this.systemTimeoutManager.destroy();
 
@@ -563,8 +579,6 @@ export class ActorSystemImpl implements ActorSystem {
     }
 
     // Cleanup request manager - handled automatically on system shutdown
-
-    await this.emitSystemEvent({ eventType: 'stopped', timestamp: Date.now() });
   }
 
   /**
@@ -1008,6 +1022,15 @@ export class ActorSystemImpl implements ActorSystem {
   private async emitSystemEvent(event: SystemEventPayload): Promise<void> {
     if (!this.systemEventActorAddress) {
       log.debug('Skipping system event emission before system event actor initialization', {
+        eventType: event.eventType,
+      });
+      return;
+    }
+
+    // Once the system event actor's mailbox is gone (its own teardown, or a
+    // direct stop), emitting would only produce dead letters — skip quietly.
+    if (!this.actorMailboxes.has(this.systemEventActorAddress.path)) {
+      log.debug('Skipping system event emission after system event actor shutdown', {
         eventType: event.eventType,
       });
       return;

--- a/packages/actor-core-runtime/src/integration/graceful-shutdown.test.ts
+++ b/packages/actor-core-runtime/src/integration/graceful-shutdown.test.ts
@@ -67,6 +67,40 @@ describe('Graceful Shutdown and Lifecycle Management', () => {
       await system.stop();
       expect(system.isRunning()).toBe(false);
     });
+
+    it('produces no dead letters on a clean spawn/emit/flush/stop cycle', async () => {
+      // Regression: stopping the system used to stop the system event actor
+      // concurrently with its peers, so every actorStopping/actorStopped
+      // emission (and the final 'stopped' event) dead-lettered against the
+      // already-gone system event actor mailbox.
+      const emitter = defineBehavior<{ type: 'PING' }>()
+        .withContext({ count: 0 })
+        .onMessage(({ message, context }) => {
+          if (message.type === 'PING') {
+            const count = context.count + 1;
+            return { context: { count }, emit: [{ type: 'PONGED', count }] };
+          }
+          return {};
+        })
+        .build();
+
+      const actorA = await system.spawn(emitter, { id: 'dead-letter-probe-a' });
+      await system.spawn(emitter, { id: 'dead-letter-probe-b' });
+
+      await actorA.send({ type: 'PING' });
+      await system.flush();
+
+      await system.stop();
+
+      // Reach into the internal queue: a clean shutdown must not dead-letter
+      // anything, system events included.
+      const deadLetters = (
+        system as unknown as {
+          deadLetterQueue: { getAll(): ReadonlyArray<{ messageType: string; reason: string }> };
+        }
+      ).deadLetterQueue.getAll();
+      expect(deadLetters).toEqual([]);
+    });
   });
 
   describe('Actor Lifecycle During Shutdown', () => {


### PR DESCRIPTION
## Summary

Fixes the runtime shutdown-ordering bug surfaced by CLI v0 (follow-up task filed in #17): a plain `startRuntime` → emit → `stop()` cycle sprayed repeated dead-letter diagnostics (`EMIT_SYSTEM_EVENT` → `Mailbox not found` / `Actor not found`) during every clean shutdown.

## Root cause

`stopSystem()` stopped **every** actor concurrently — including the **system event actor** — while each peer's `stopActor()` emitted `actorStopping`/`actorStopped` *to* that same actor. Once its mailbox died mid-loop, every remaining emission dead-lettered, and the final `'stopped'` event always dead-lettered because it fired after full teardown.

## Fix (two small changes in `actor-system-impl.ts`)

1. `stopSystem()` skips the system event actor in the concurrent stop loop, emits the final `'stopped'` event while it is still alive, and stops it **last**.
2. `emitSystemEvent()` skips quietly (debug log) once the event actor's mailbox is gone — covers its own `actorStopped` self-emission during its own teardown and direct `stop(pid)` of the event actor.

## Verification

- New regression test in `graceful-shutdown.test.ts`: spawn two emitting actors → send → flush → stop → **dead-letter queue is empty**. Confirmed it **fails with 5 dead letters** when the ordering fix is reverted.
- Full runtime suite: **406 passed, 0 regressions**.
- End-to-end through the CLI (rebuilt dist): an `actor-web serve --exec` session now ends **completely clean** — previously every session ended with ~7 dead-letter blocks.
- `verify.sh --full` → ALL PASSED.

## Scope

`packages/actor-core-runtime/src/actor-system-impl.ts` + the regression test. Closes the tracker task "Runtime: silence system-event dead letters during startRuntime stop()".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system shutdown sequence to ensure critical events are properly emitted during cleanup.
  * Prevented unnecessary warnings during shutdown by avoiding message delivery to stopped system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->