### PR TITLE
chore(fas): queue substrate-hardening + @actor-web/agent tasks; file release-prep

### DIFF
--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1239,6 +1239,15 @@
 - Owner: planner
 - Brief: .fas/tasks/release-prep-0-2-0-ship-actor-web-agent-decide-the-publi.md
 
+### Task: Docs: refresh root + runtime READMEs to the real post-rename API (remove fictional feature claims)
+
+- Title: Docs: refresh root + runtime READMEs to the real post-rename API (remove fictional feature claims)
+- Mode: 4-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/docs-refresh-root-runtime-readmes-to-the-real-post-rename.md
+- Automation mode: advisory
+
 ## Template
 
 ### Task: `<short task title>`

--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1163,8 +1163,8 @@
 
 - Title: actor-web CLI v1: @actor-web/agent package (llm tool + agent-loop) + agent hosting
 - Mode: single-agent
-- Status: backlog
-- Owner: planner
+- Status: queued
+- Owner: runtime
 - Brief: .fas/tasks/actor-web-cli-v1-actor-web-agent-package-llm-tool-agent.md
 - Automation mode: advisory
 
@@ -1205,10 +1205,39 @@
 
 - Title: Runtime: silence system-event dead letters during startRuntime stop()
 - Mode: single-agent
-- Status: backlog
-- Owner: planner
+- Status: implementing
+- Owner: implementer
 - Brief: .fas/tasks/runtime-silence-system-event-dead-letters-during-startrunti.md
 - Automation mode: advisory
+- Verification lane: fast
+- Policy sensitivity: standard
+- Blast radius: cross-cutting
+
+### Task: Runtime: prove supervision restart under failure (regression coverage)
+
+- Title: Runtime: prove supervision restart under failure (regression coverage)
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/runtime-prove-supervision-restart-under-failure-regression.md
+- Automation mode: advisory
+
+### Task: Runtime: tool execution timeout/cancellation + real-async tool e2e coverage
+
+- Title: Runtime: tool execution timeout/cancellation + real-async tool e2e coverage
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/runtime-tool-execution-timeout-cancellation-real-async-to.md
+- Automation mode: advisory
+
+### Task: Release prep 0.2.0: ship @actor-web/agent + decide the public package facade
+
+- Title: Release prep 0.2.0: ship @actor-web/agent + decide the public package facade
+- Mode: single-agent
+- Status: backlog
+- Owner: planner
+- Brief: .fas/tasks/release-prep-0-2-0-ship-actor-web-agent-decide-the-publi.md
 
 ## Template
 

--- a/.fas/tasks/docs-refresh-root-runtime-readmes-to-the-real-post-rename.md
+++ b/.fas/tasks/docs-refresh-root-runtime-readmes-to-the-real-post-rename.md
@@ -1,0 +1,77 @@
+# Docs: refresh root + runtime READMEs to the real post-rename
+
+## Source
+
+Created with `fas create-task` on 2026-06-10.
+
+## Problem
+
+Docs accuracy audit (2026-06-10). The runtime README ships in the npm tarball, so npmjs.com/package/@actor-web/runtime renders it — fixes only reach npm at the next publish (tie to Release prep 0.2.0). FINDINGS: (1) ROOT README.md — 13 uses of defineActor() (renamed defineBehavior 2026-06-09, defineActor is NOT exported); line ~167 calls createSupervisor() which does not exist (real APIs: Supervisor class, createSupervisorTree); inconsistent .build() messaging (.build() is OPTIONAL since 2026-06-09 — pick one style and say so once). (2) packages/actor-core-runtime/README.md — JSDoc module says @actor-core/runtime; 'Migration Notice' references a legacy /src/core that no longer exists in this repo (confusing on the npm page); FICTIONAL feature claims with zero source behind them: 'Virtual Actor System (Orleans-style)' (0 files), 'tRPC-Inspired Proxies' (0 files), 'HTN planning/AI agent patterns' (1 stray mention); 'Capability Security' overstated (the real mechanism is the toolAccess allow-list). Remove or rewrite claims to match shipped reality. (3) docs/API.md — mostly ACCURATE (correct defineBehavior/startRuntime/serveNode/@actor-web scope); minor: .build() consistency + 11 Ignite-naming references (overlaps queued ignite docs tasks — do not duplicate that scope). (4) packages/actor-core-testing/README.md ACCURATE; cli README ACCURATE (v0). Marketing claims must be provable by a test or source file. Remember: markdown outside .fas/ is NOT verify-linted — run markdownlint-cli2 on touched files.
+
+## Automation admission
+
+- Expected operator value: Improves operator leverage around "Docs: refresh root + runtime READMEs to the real post-rename API (remove fictional feature claims)" by reducing manual coordination, repetitive execution, or trust gaps.
+- Observability surface: Use authoritative FAS surfaces such as `fas runtime status`, `fas runtime watch`, workflow logs, receipts, or notifications to show whether the automation is active, quiet, stalled, blocked, or complete.
+- Recovery path: A human can abort, retry, recover, or rerun this workflow without leaving stale queue, lease, branch, or current-task state.
+- Autonomy mode: advisory
+- Promotion criteria: Promote beyond advisory only after dogfood runs prove clear operator value, trustworthy observability, and bounded recovery.
+
+## Acceptance criteria
+
+- root README uses only exported APIs (defineBehavior, Supervisor/createSupervisorTree) and every code fence compiles conceptually against the real surface
+- runtime README has no claims without corresponding source/tests, no /src/core migration notice, and @actor-web module naming
+- .build() optionality stated once and used consistently across README/API.md
+- touched markdown passes markdownlint-cli2
+- TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
+- TDD: every production code change in the change set is covered by an added or updated test.
+- DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.
+- The work is tracked in `.fas/TASKS.md`.
+- The task has a clear implementation and verification plan before execution starts.
+- The task is queued in `.fas/queue/tasks.json` for the runtime.
+
+## Proposed solution
+
+- Use the supplied problem context, acceptance criteria, and affected-file hints to draft the concrete implementation approach during planning.
+
+## Alternatives considered
+
+- None recorded at task creation. Add rejected approaches during planning if scope tradeoffs appear.
+
+## Affected files
+
+- Scope unknown.
+
+## Scope Amendments
+
+- None.
+
+## Implementation plan
+
+- Convert the supplied context into a scoped implementation plan before editing.
+- Refresh affected-file scope before implementation if the generated hints are incomplete.
+
+## Verification plan
+
+- Run `fas validate-task` for the inner-loop verification gate.
+- Run `.fas/scripts/verify.sh --full` at the final release-quality gate when tracked files change.
+
+## Risks
+
+- Validate generated scope, acceptance criteria, and verification evidence before closeout to avoid workflow drift.
+
+## Dependencies
+
+- None known at task creation.
+
+## Open questions
+
+- None captured at task creation.
+
+## Artifact links
+
+- Planning: `.fas/state/planning.json`
+- Task packet: `.fas/state/task-packet.json`
+- Commit plan: `.fas/state/commit-plan.json`
+- Verification: `.fas/state/verification/latest.json`
+- Review: `.fas/state/boundary-review-findings.md`
+- Workflow: `.fas/state/workflows/`

--- a/.fas/tasks/release-prep-0-2-0-ship-actor-web-agent-decide-the-publi.md
+++ b/.fas/tasks/release-prep-0-2-0-ship-actor-web-agent-decide-the-publi.md
@@ -1,0 +1,68 @@
+# Release prep 0.2.0: ship @actor-web/agent + decide the publi
+
+## Source
+
+Created with `fas create-task` on 2026-06-10.
+
+## Problem
+
+SEQUENCE AFTER @actor-web/agent (CLI v1) ships. Prep the next npm release line: (1) changesets for runtime/testing changes accumulated since 0.1.0 (incl. the shutdown dead-letter fix, PR #18) and the new @actor-web/agent package's first publish; (2) decide @actor-web/cli publish posture (still private; see the deferred cli-publish task); (3) DECISION REQUIRED: public package facade — whether to publish an unscoped 'actor-web' package as the public API surface (re-exporting the supported surface) while keeping @actor-web/*scoped packages as internal implementation, mirroring how ignite-element ships 'ignite-element' (unscoped) over @ignite-element/* internals. Record the decision in docs/ and decisions memory; if adopted, the facade package + changeset fixed-group membership land here; (4) consider the Changesets GitHub Action so releases run via a Version Packages PR instead of local bypass-push (repo main is PR-protected).
+
+## Acceptance criteria
+
+- changesets exist for all publishable changes since 0.1.0
+- @actor-web/agent first-publish plumbing verified with npm pack --dry-run
+- facade decision recorded (adopted or rejected) in docs/ and .fas memory
+- release executed or handed to the user with exact steps
+- TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
+- TDD: every production code change in the change set is covered by an added or updated test.
+- DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.
+- The work is tracked in `.fas/TASKS.md`.
+- The task has a clear implementation and verification plan before execution starts.
+
+## Proposed solution
+
+- Use the supplied problem context, acceptance criteria, and affected-file hints to draft the concrete implementation approach during planning.
+
+## Alternatives considered
+
+- None recorded at task creation. Add rejected approaches during planning if scope tradeoffs appear.
+
+## Affected files
+
+- Scope unknown.
+
+## Scope Amendments
+
+- None.
+
+## Implementation plan
+
+- Convert the supplied context into a scoped implementation plan before editing.
+- Refresh affected-file scope before implementation if the generated hints are incomplete.
+
+## Verification plan
+
+- Run `fas validate-task` for the inner-loop verification gate.
+- Run `.fas/scripts/verify.sh --full` at the final release-quality gate when tracked files change.
+
+## Risks
+
+- Validate generated scope, acceptance criteria, and verification evidence before closeout to avoid workflow drift.
+
+## Dependencies
+
+- None known at task creation.
+
+## Open questions
+
+- None captured at task creation.
+
+## Artifact links
+
+- Planning: `.fas/state/planning.json`
+- Task packet: `.fas/state/task-packet.json`
+- Commit plan: `.fas/state/commit-plan.json`
+- Verification: `.fas/state/verification/latest.json`
+- Review: `.fas/state/boundary-review-findings.md`
+- Workflow: `.fas/state/workflows/`

--- a/.fas/tasks/runtime-prove-supervision-restart-under-failure-regression.md
+++ b/.fas/tasks/runtime-prove-supervision-restart-under-failure-regression.md
@@ -1,0 +1,77 @@
+# Runtime: prove supervision restart under failure (regression
+
+## Source
+
+Created with `fas create-task` on 2026-06-10.
+
+## Problem
+
+Surfaced by the fas-studio agents-with-tools readiness assessment (2026-06-10). The Supervisor class (packages/actor-core-runtime/src/actors/supervisor.ts) and SupervisionStrategy directives (actor-system.ts RESTART/STOP/ESCALATE/RESUME) exist, and topologies declare supervision (strategy/maxRestarts/withinMs), but ZERO tests exercise an actor failing and being restarted. Before fas-studio relies on supervision for agent orchestration we need regression coverage: (1) actor throws in onMessage -> supervisor restarts it -> actor processes messages again; (2) maxRestarts exceeded within the window -> actor stays stopped; (3) stop/escalate/resume directives behave as documented; (4) supervision declared via defineActorWebTopology supervision field is actually enforced at runtime. Fix any gaps the tests expose (restart may be partially or not wired). SEQUENCE: independent; prioritize before @actor-web/agent work.
+
+## Automation admission
+
+- Expected operator value: Improves operator leverage around "Runtime: prove supervision restart under failure (regression coverage)" by reducing manual coordination, repetitive execution, or trust gaps.
+- Observability surface: Use authoritative FAS surfaces such as `fas runtime status`, `fas runtime watch`, workflow logs, receipts, or notifications to show whether the automation is active, quiet, stalled, blocked, or complete.
+- Recovery path: A human can abort, retry, recover, or rerun this workflow without leaving stale queue, lease, branch, or current-task state.
+- Autonomy mode: advisory
+- Promotion criteria: Promote beyond advisory only after dogfood runs prove clear operator value, trustworthy observability, and bounded recovery.
+
+## Acceptance criteria
+
+- an e2e test kills an actor via a thrown handler error and proves the supervisor restarts it and it processes again
+- maxRestarts within the window is enforced and tested
+- topology-declared supervision (strategy/maxRestarts) is exercised end-to-end
+- any restart-path gaps found are fixed in the same task
+- TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
+- TDD: every production code change in the change set is covered by an added or updated test.
+- DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.
+- The work is tracked in `.fas/TASKS.md`.
+- The task has a clear implementation and verification plan before execution starts.
+- The task is queued in `.fas/queue/tasks.json` for the runtime.
+
+## Proposed solution
+
+- Use the supplied problem context, acceptance criteria, and affected-file hints to draft the concrete implementation approach during planning.
+
+## Alternatives considered
+
+- None recorded at task creation. Add rejected approaches during planning if scope tradeoffs appear.
+
+## Affected files
+
+- Scope unknown.
+
+## Scope Amendments
+
+- None.
+
+## Implementation plan
+
+- Convert the supplied context into a scoped implementation plan before editing.
+- Refresh affected-file scope before implementation if the generated hints are incomplete.
+
+## Verification plan
+
+- Run `fas validate-task` for the inner-loop verification gate.
+- Run `.fas/scripts/verify.sh --full` at the final release-quality gate when tracked files change.
+
+## Risks
+
+- Validate generated scope, acceptance criteria, and verification evidence before closeout to avoid workflow drift.
+
+## Dependencies
+
+- None known at task creation.
+
+## Open questions
+
+- None captured at task creation.
+
+## Artifact links
+
+- Planning: `.fas/state/planning.json`
+- Task packet: `.fas/state/task-packet.json`
+- Commit plan: `.fas/state/commit-plan.json`
+- Verification: `.fas/state/verification/latest.json`
+- Review: `.fas/state/boundary-review-findings.md`
+- Workflow: `.fas/state/workflows/`

--- a/.fas/tasks/runtime-tool-execution-timeout-cancellation-real-async-to.md
+++ b/.fas/tasks/runtime-tool-execution-timeout-cancellation-real-async-to.md
@@ -1,0 +1,77 @@
+# Runtime: tool execution timeout/cancellation + real-async to
+
+## Source
+
+Created with `fas create-task` on 2026-06-10.
+
+## Problem
+
+Surfaced by the fas-studio agents-with-tools readiness assessment (2026-06-10). tools.execute (packages/actor-core-runtime/src/actor-tools.ts createActorToolbox) awaits a tool promise indefinitely: a hung tool (e.g. a slow/stuck LLM call) wedges its actor forever — no deadline, no cancellation, no fallback. Existing coverage uses only fake synchronous tools (unit actor-tools.test.ts; examples/fas-agent-loop). Needed before agents call real model APIs: (1) deadline support for tool execution — per-call timeout option and/or registry-level default, with an AbortSignal exposed via ActorToolExecutionContext so adapters can cancel underlying requests; (2) timeout produces a typed error/fact the behavior can handle without crashing the actor; (3) an e2e test where a spawned actor calls a REAL async tool (timer-backed) and a hung tool times out while the actor stays responsive; (4) document the timeout pattern for tool authors. Keep the core deterministic — timers via the runtime's existing timeout utilities, not ad-hoc setTimeout in the core.
+
+## Automation admission
+
+- Expected operator value: Improves operator leverage around "Runtime: tool execution timeout/cancellation + real-async tool e2e coverage" by reducing manual coordination, repetitive execution, or trust gaps.
+- Observability surface: Use authoritative FAS surfaces such as `fas runtime status`, `fas runtime watch`, workflow logs, receipts, or notifications to show whether the automation is active, quiet, stalled, blocked, or complete.
+- Recovery path: A human can abort, retry, recover, or rerun this workflow without leaving stale queue, lease, branch, or current-task state.
+- Autonomy mode: advisory
+- Promotion criteria: Promote beyond advisory only after dogfood runs prove clear operator value, trustworthy observability, and bounded recovery.
+
+## Acceptance criteria
+
+- a hung tool call times out with a typed error and the calling actor remains responsive (tested)
+- AbortSignal (or equivalent cancellation hook) reaches the tool executor context
+- an e2e test exercises a real async tool from a spawned actor through tools.execute
+- timeout behavior is documented for tool authors
+- TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
+- TDD: every production code change in the change set is covered by an added or updated test.
+- DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.
+- The work is tracked in `.fas/TASKS.md`.
+- The task has a clear implementation and verification plan before execution starts.
+- The task is queued in `.fas/queue/tasks.json` for the runtime.
+
+## Proposed solution
+
+- Use the supplied problem context, acceptance criteria, and affected-file hints to draft the concrete implementation approach during planning.
+
+## Alternatives considered
+
+- None recorded at task creation. Add rejected approaches during planning if scope tradeoffs appear.
+
+## Affected files
+
+- Scope unknown.
+
+## Scope Amendments
+
+- None.
+
+## Implementation plan
+
+- Convert the supplied context into a scoped implementation plan before editing.
+- Refresh affected-file scope before implementation if the generated hints are incomplete.
+
+## Verification plan
+
+- Run `fas validate-task` for the inner-loop verification gate.
+- Run `.fas/scripts/verify.sh --full` at the final release-quality gate when tracked files change.
+
+## Risks
+
+- Validate generated scope, acceptance criteria, and verification evidence before closeout to avoid workflow drift.
+
+## Dependencies
+
+- None known at task creation.
+
+## Open questions
+
+- None captured at task creation.
+
+## Artifact links
+
+- Planning: `.fas/state/planning.json`
+- Task packet: `.fas/state/task-packet.json`
+- Commit plan: `.fas/state/commit-plan.json`
+- Verification: `.fas/state/verification/latest.json`
+- Review: `.fas/state/boundary-review-findings.md`
+- Workflow: `.fas/state/workflows/`


### PR DESCRIPTION
FAS queue/tracker bookkeeping (no source changes). From the fas-studio agents-with-tools readiness assessment:

**Queued (next up, in order of intent):**
1. *Runtime: prove supervision restart under failure* (high) — `Supervisor` + strategies exist, zero failure→restart tests; fix gaps the tests expose.
2. *Runtime: tool execution timeout/cancellation + real-async tool e2e* (high) — `tools.execute` awaits indefinitely; agents calling real model APIs need deadlines + AbortSignal + a typed timeout error.
3. *actor-web CLI v1: `@actor-web/agent`* — promoted from backlog (v0 merged in #17); sequence-preference after 1–2.

**Backlog:** *Release prep 0.2.0* — changesets since 0.1.0 (incl. #18), `@actor-web/agent` first publish, the unscoped `actor-web` facade-package decision (ignite-element pattern), and the Changesets GitHub Action consideration. Sequenced after v1 per plan.

**Cross-repo filing (kept in each repo's own queue):**
- `../fas-studio`: *wire one real `tools.execute` call through a behavior* — committed on their `fas/client-zero-milestone` branch.
- `../FAS` (platform): bug — `create-task` in-place title update drops the existing `Brief:` pointer when run with `--no-brief` (observed promoting v1 here; pointer restored manually in this PR).

Also picks up the dead-letter task's `implementing` status from the PR #18 bootstrap. `.fas` markdown lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated task tracking metadata for actor-web CLI and runtime components.
  * Added planning documentation for 0.2.0 release sequence, including validation and publication strategy decisions.
  * Created task specifications for supervision restart regression testing and tool execution timeout/cancellation features with verification and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->