### PR TITLE
feat: deploy VitePress docs to GitHub Pages at /actor-web/ subpath

### DIFF
--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1316,8 +1316,8 @@
 
 - Title: Deploy VitePress docs to GitHub Pages at /actor-web/ subpath
 - Mode: single-agent
-- Status: implementing
-- Owner: implementer
+- Status: review
+- Owner: reviewer
 - Brief: .fas/tasks/deploy-vitepress-docs-to-github-pages-at-actor-web-subpath.md
 - Verification lane: fast
 - Policy sensitivity: standard

--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1312,6 +1312,17 @@
 - Policy sensitivity: standard
 - Blast radius: cross-cutting
 
+### Task: Deploy VitePress docs to GitHub Pages at /actor-web/ subpath
+
+- Title: Deploy VitePress docs to GitHub Pages at /actor-web/ subpath
+- Mode: single-agent
+- Status: implementing
+- Owner: implementer
+- Brief: .fas/tasks/deploy-vitepress-docs-to-github-pages-at-actor-web-subpath.md
+- Verification lane: fast
+- Policy sensitivity: standard
+- Blast radius: cross-cutting
+
 ## Template
 
 ### Task: `<short task title>`

--- a/.fas/tasks/deploy-vitepress-docs-to-github-pages-at-actor-web-subpath.md
+++ b/.fas/tasks/deploy-vitepress-docs-to-github-pages-at-actor-web-subpath.md
@@ -1,0 +1,64 @@
+# Deploy VitePress docs to GitHub Pages at /actor-web/ subpath
+
+## Source
+
+Created with `fas create-task` on 2026-06-11.
+
+## Problem
+
+Deploy VitePress docs to GitHub Pages at /actor-web/ subpath
+
+## Acceptance criteria
+
+- The work is tracked in `.fas/TASKS.md`.
+- The task has a clear implementation and verification plan before execution starts.
+
+## Proposed solution
+
+- Use the supplied problem context, acceptance criteria, and affected-file hints to draft the concrete implementation approach during planning.
+
+## Alternatives considered
+
+- None recorded at task creation. Add rejected approaches during planning if scope tradeoffs appear.
+
+## Affected files
+
+- docs/site/.vitepress/config.ts
+- .github/workflows/docs.yml
+- .github/workflows/docs-contrast.yml
+- README.md
+
+## Scope Amendments
+
+- None.
+
+## Implementation plan
+
+- Convert the supplied context into a scoped implementation plan before editing.
+- Refresh affected-file scope before implementation if the generated hints are incomplete.
+
+## Verification plan
+
+- Run `fas validate-task` for the inner-loop verification gate.
+- Run `.fas/scripts/verify.sh --full` at the final release-quality gate when tracked files change.
+
+## Risks
+
+- Validate generated scope, acceptance criteria, and verification evidence before closeout to avoid workflow drift.
+
+## Dependencies
+
+- None known at task creation.
+
+## Open questions
+
+- None captured at task creation.
+
+## Artifact links
+
+- Planning: `.fas/state/planning.json`
+- Task packet: `.fas/state/task-packet.json`
+- Commit plan: `.fas/state/commit-plan.json`
+- Verification: `.fas/state/verification/latest.json`
+- Review: `.fas/state/boundary-review-findings.md`
+- Workflow: `.fas/state/workflows/`

--- a/.github/workflows/docs-contrast.yml
+++ b/.github/workflows/docs-contrast.yml
@@ -3,10 +3,8 @@ name: Docs Contrast & Lint
 # Renders the built VitePress docs site in headless Chromium and fails the PR if
 # any key chrome/content selector drops below WCAG AA contrast in either theme,
 # and lints the site markdown. Scoped to PRs that touch docs/site so non-docs PRs
-# don't pay the browser cost.
-#
-# Note: GitHub automation may be disabled for this repo (see .fas-config.json
-# runtimeGitHubEnabled). This workflow is correct and dormant until CI is on.
+# don't pay the browser cost. Because main is PR-protected, this check gates
+# what can reach the Pages deploy in docs.yml.
 
 on:
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,15 @@
 name: Docs
 
-# Build the VitePress docs site. The build runs @shikijs/vitepress-twoslash,
-# which type-checks every ```ts twoslash sample against the real
-# @actor-web/runtime types — so doc drift fails the build.
+# Build the VitePress docs site and deploy it to GitHub Pages.
 #
-# Note: GitHub automation may be disabled for this repo (see .fas-config.json
-# runtimeGitHubEnabled). This workflow is correct and dormant until CI is on.
+# The build runs @shikijs/vitepress-twoslash, which type-checks every
+# ```ts twoslash sample against the real @actor-web/runtime types — so doc
+# drift fails the build (and therefore blocks the deploy).
+#
+# Deploys publish to https://0xjcf.github.io/actor-web/ (Pages source must be
+# set to "GitHub Actions" in the repo settings). Runtime changes are included
+# in the push trigger because twoslash bakes type info into the rendered
+# pages — without a rebuild, published hover-types go stale.
 
 on:
   pull_request:
@@ -17,7 +21,9 @@ on:
     branches: [main]
     paths:
       - 'docs/site/**'
+      - 'packages/actor-core-runtime/**'
       - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -37,3 +43,27 @@ jobs:
         run: pnpm --filter @actor-web/runtime build
       - name: Build docs (twoslash typecheck gate)
         run: pnpm run test:docs
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site/.vitepress/dist
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    # Queue production deploys instead of cancelling one mid-flight.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 > **Pure Actor Model for JavaScript/TypeScript** - Build resilient, distributed systems with location-transparent actors, inspired by Erlang/OTP
 
+[![Docs](https://img.shields.io/badge/Docs-0xjcf.github.io%2Factor--web-blue)](https://0xjcf.github.io/actor-web/)
 [![Pure Actor Model](https://img.shields.io/badge/Pure%20Actor%20Model-100%25%20Compliant-green)](https://github.com/0xjcf/actor-web)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue)](https://www.typescriptlang.org/)
 [![Workspace Packages](https://img.shields.io/badge/Workspace-packages%2F*-brightgreen)](./pnpm-workspace.yaml)
+
+**📚 Documentation: [0xjcf.github.io/actor-web](https://0xjcf.github.io/actor-web/)**
 
 ## 🚀 Why Actor-Web?
 

--- a/docs/site/.vitepress/config.ts
+++ b/docs/site/.vitepress/config.ts
@@ -9,7 +9,12 @@ export default defineConfig({
     'Pure actor model for JavaScript/TypeScript — location-transparent actors, inspired by Erlang/OTP.',
   cleanUrls: true,
   lastUpdated: true,
-  // Deployment base (e.g. GitHub Pages "/actor-web/") is decided in docs task D6.
+  // GitHub Pages project site: deployed by .github/workflows/docs.yml to
+  // https://0xjcf.github.io/actor-web/ — base must match the repo subpath.
+  base: '/actor-web/',
+  sitemap: {
+    hostname: 'https://0xjcf.github.io/actor-web/',
+  },
   markdown: {
     // Typecheck every ```ts twoslash fence against the real @actor-web/runtime
     // types at build time — drift breaks the build.


### PR DESCRIPTION
## Summary

Turns the existing docs build check into a full Pages deployment pipeline. Pages source is already set to **GitHub Actions** in repo settings; this PR supplies the missing pieces:

- **Deploy job in docs.yml**: `actions/upload-pages-artifact` (from `docs/site/.vitepress/dist`) → `actions/deploy-pages`, on main pushes and `workflow_dispatch`. The existing build job stays the PR-time twoslash typecheck gate; deploys queue (not cancel) via the `pages` concurrency group.
- **`base: '/actor-web/'`** in the VitePress config — the deferred D6 decision — plus `sitemap.hostname`. Without the base, project-pages assets 404.
- **Runtime paths added to the push trigger**: twoslash bakes type info into rendered pages, so runtime merges rebuild the site and keep published hover-types fresh.
- **README** links the published site; stale 'dormant until CI is on' notes removed from both docs workflows (CI is live); docs-contrast note clarifies it gates deploys via PR protection.

## Verification

- `pnpm --filter @actor-web/runtime build && pnpm docs:build`: clean build, all asset URLs `/actor-web/`-prefixed, sitemap generated
- Served the built site locally (`vitepress preview`) and verified in a real browser: home page and deep pages render under `/actor-web/` with sidebar/nav intact, **zero console errors, zero failed asset requests**
- `.fas/scripts/verify.sh`: ALL PASSED; `fas validate-task`: plan alignment clean

## Deploy validation plan

Merge **this PR first**, then merge #21 — #21 touches both `docs/site/**` and the runtime package, so it will trigger the first automated deploy and serve as live validation of the pipeline. Site lands at https://0xjcf.github.io/actor-web/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Documentation deployed and accessible via GitHub Pages
  
* **Documentation**
  * Added documentation badge and link to project README
  * Configured VitePress documentation site for GitHub Pages deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->