### PR TITLE
fix(docs): correct supervision restart claims; mark subscriptions as shipped

### DIFF
--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1328,6 +1328,17 @@
 - Policy sensitivity: standard
 - Blast radius: cross-cutting
 
+### Task: Fix docs-site discrepancies from 2026-06-11 audit (supervision persistence claim, stale subscriptions hero)
+
+- Title: Fix docs-site discrepancies from 2026-06-11 audit (supervision persistence claim, stale subscriptions hero)
+- Mode: single-agent
+- Status: implementing
+- Owner: implementer
+- Brief: .fas/tasks/fix-docs-site-discrepancies-from-2026-06-11-audit-supervisi.md
+- Verification lane: fast
+- Policy sensitivity: standard
+- Blast radius: cross-cutting
+
 ## Template
 
 ### Task: `<short task title>`

--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1332,8 +1332,8 @@
 
 - Title: Fix docs-site discrepancies from 2026-06-11 audit (supervision persistence claim, stale subscriptions hero)
 - Mode: single-agent
-- Status: implementing
-- Owner: implementer
+- Status: review
+- Owner: reviewer
 - Brief: .fas/tasks/fix-docs-site-discrepancies-from-2026-06-11-audit-supervisi.md
 - Verification lane: fast
 - Policy sensitivity: standard

--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1271,13 +1271,15 @@
 
 - Title: Resolve unenforced SendInstruction delivery modes (retry(3), guaranteed)
 - Mode: single-agent
-- Status: review
+- Status: done
 - Owner: reviewer
 - Brief: .fas/tasks/resolve-unenforced-sendinstruction-delivery-modes-retry-3.md
 - Automation mode: advisory
 - Verification lane: fast
 - Policy sensitivity: standard
 - Blast radius: cross-cutting
+- Artifacts: pr=<https://github.com/0xjcf/actor-web/pull/21>; verification=.fas/state/verification/latest.json
+- Note: status set to done manually after PR #21 merged — task passed validate/review but was superseded as current task by the docs-deploy task before `fas done` could run (no batch snapshot existed)
 
 ### Task: Author the lattice contract design doc (artifact store + dependency activation)
 
@@ -1319,8 +1321,8 @@
 
 - Title: Deploy VitePress docs to GitHub Pages at /actor-web/ subpath
 - Mode: single-agent
-- Status: review
-- Owner: reviewer
+- Status: done
+- Owner: implementer
 - Brief: .fas/tasks/deploy-vitepress-docs-to-github-pages-at-actor-web-subpath.md
 - Verification lane: fast
 - Policy sensitivity: standard

--- a/.fas/tasks/deploy-vitepress-docs-to-github-pages-at-actor-web-subpath.md
+++ b/.fas/tasks/deploy-vitepress-docs-to-github-pages-at-actor-web-subpath.md
@@ -27,10 +27,19 @@ Deploy VitePress docs to GitHub Pages at /actor-web/ subpath
 - .github/workflows/docs.yml
 - .github/workflows/docs-contrast.yml
 - README.md
+- packages/actor-core-runtime/src/message-plan.ts
+- packages/actor-core-runtime/src/otp-message-plan-processor.ts
+- packages/actor-core-runtime/src/unit/message-plan.test.ts
+- packages/actor-core-runtime/src/unit/message-plan.unit.test.ts
+- docs/site/concepts/messages.md
+- docs/site/api/define-behavior.md
+- .fas/memory/decisions.md
+- .fas/memory/pr-feedback.md
+- .fas/memory/incidents.md
 
 ## Scope Amendments
 
-- None.
+- 2026-06-11 (closeout-window accounting, not implementation scope): PR #22 (this task) merged to main BEFORE PR #21 (the already-validated "Resolve unenforced SendInstruction delivery modes" task), so the closeout diff window `workflowStartHeadSha..HEAD` unavoidably contains PR #21's files (message-plan.ts, otp-message-plan-processor.ts, two message-plan test files, two docs-site pages, three memory files). Those files belong to the completed sibling task, were reviewed and merged through its own pipeline, and were NOT touched by this task's implementation (which changed only the four files listed first). Added here solely so the NO_UNPLANNED_SOURCE_FILES closeout gate reflects the interleaved-merge reality — the platform-side fix (derive the closeout window from the PR's own merge commit first-parent diff) is filed in the FAS repo queue (2026-06-11).
 
 ## Implementation plan
 

--- a/.fas/tasks/fix-docs-site-discrepancies-from-2026-06-11-audit-supervisi.md
+++ b/.fas/tasks/fix-docs-site-discrepancies-from-2026-06-11-audit-supervisi.md
@@ -1,0 +1,62 @@
+# Fix docs-site discrepancies from 2026-06-11 audit (supervisi
+
+## Source
+
+Created with `fas create-task` on 2026-06-11.
+
+## Problem
+
+Fix docs-site discrepancies from 2026-06-11 audit (supervision persistence claim, stale subscriptions hero)
+
+## Acceptance criteria
+
+- The work is tracked in `.fas/TASKS.md`.
+- The task has a clear implementation and verification plan before execution starts.
+
+## Proposed solution
+
+- Use the supplied problem context, acceptance criteria, and affected-file hints to draft the concrete implementation approach during planning.
+
+## Alternatives considered
+
+- None recorded at task creation. Add rejected approaches during planning if scope tradeoffs appear.
+
+## Affected files
+
+- docs/site/concepts/supervision.md
+- docs/site/index.md
+
+## Scope Amendments
+
+- None.
+
+## Implementation plan
+
+- Convert the supplied context into a scoped implementation plan before editing.
+- Refresh affected-file scope before implementation if the generated hints are incomplete.
+
+## Verification plan
+
+- Run `fas validate-task` for the inner-loop verification gate.
+- Run `.fas/scripts/verify.sh --full` at the final release-quality gate when tracked files change.
+
+## Risks
+
+- Validate generated scope, acceptance criteria, and verification evidence before closeout to avoid workflow drift.
+
+## Dependencies
+
+- None known at task creation.
+
+## Open questions
+
+- None captured at task creation.
+
+## Artifact links
+
+- Planning: `.fas/state/planning.json`
+- Task packet: `.fas/state/task-packet.json`
+- Commit plan: `.fas/state/commit-plan.json`
+- Verification: `.fas/state/verification/latest.json`
+- Review: `.fas/state/boundary-review-findings.md`
+- Workflow: `.fas/state/workflows/`

--- a/docs/site/concepts/supervision.md
+++ b/docs/site/concepts/supervision.md
@@ -42,11 +42,18 @@ than transient.
 
 ## What survives a restart
 
-A restarted actor starts from its initial context (or its last persisted state
-where configured). Subscriptions registered against a restarted actor are
-preserved when it respawns with the same id. A full *system* restart, by
-contrast, starts fresh — durable state belongs in adapters/stores, not actor
-memory.
+A restarted actor starts from its initial context. Durable state is not yet a
+runtime feature — if state must survive restarts, re-derive it from an external
+source in `onStart`. Restarting to a known-good initial state is deliberate
+("let it crash"): silently resuming the exact state that preceded a crash risks
+restarting straight back into the failure.
+
+Subscriptions split by how they were registered: topology-declared
+`subscriptions` are durable — the runtime re-wires them from the topology on
+every start. Imperative `system.subscribe(...)` registrations survive a
+supervised single-actor restart (same id) but are in-memory and lost on a full
+*system* restart. Either way, durable state belongs in adapters/stores, not
+actor memory.
 
 ## Why this beats defensive coding
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -17,7 +17,7 @@ features:
   - title: Actors, not call stacks
     details: Behaviors handle one message at a time over isolated state. No shared mutable state, no race conditions by construction.
   - title: Topology-declared runtime
-    details: Declare nodes, actors, and supervisors once. The runtime owns placement, lifecycle, and (soon) inter-actor subscriptions.
+    details: Declare nodes, actors, supervisors, and subscriptions once. The runtime owns placement, lifecycle, and inter-actor event wiring — re-established on every start.
   - title: Type-safe messages & events
     details: Message and event unions flow from defineBehavior through the topology to your UI sources — checked end to end.
 ---


### PR DESCRIPTION
## Summary

First of the three queued audit/honesty tasks (from the 2026-06-11 three-agent docs audit).

- **supervision.md**: removed the claim that restarts can resume from 'last persisted state where configured' — `persistState` is declared on `SpawnOptions` but has zero consumers; restarts always start from initial context, and that's deliberate (let-it-crash: resuming pre-crash state risks restarting straight into the failure). New text tells readers to re-derive durable state from an external source in `onStart`. Also distinguishes durable topology-declared subscriptions (re-wired on every start) from imperative `system.subscribe` ones (in-memory, lost on system restart).
- **index.md hero**: '(soon) inter-actor subscriptions' → states declarative subscriptions as shipped (PR #20).
- Carries the closeout bookkeeping from PRs #20-#22 (task tracker statuses, interleaved-merge scope amendment) and the queued SpawnOptions-honesty brief.

The companion type-level cleanup (remove `persistState`/`timeout`/`retries` from `SpawnOptions`, decide `supervised` semantics) is the queued follow-up task; the decision rationale is recorded in `.fas/memory/decisions.md`.

## Verification

- `pnpm docs:build` (twoslash gate) clean; `docs:lint:md` clean; `.fas/scripts/verify.sh --full` ALL PASSED; `fas validate-task` plan alignment fully clean
- Merging this triggers a Pages deploy (docs/site/** path) — the corrected supervision page goes live automatically