### PR TITLE
docs: refresh root and runtime READMEs to the real post-rename API

### DIFF
--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1243,8 +1243,8 @@
 
 - Title: Docs: refresh root + runtime READMEs to the real post-rename API (remove fictional feature claims)
 - Mode: 4-agent
-- Status: queued
-- Owner: runtime
+- Status: review
+- Owner: reviewer
 - Brief: .fas/tasks/docs-refresh-root-runtime-readmes-to-the-real-post-rename.md
 - Automation mode: advisory
 
@@ -1332,9 +1332,20 @@
 
 - Title: Fix docs-site discrepancies from 2026-06-11 audit (supervision persistence claim, stale subscriptions hero)
 - Mode: single-agent
-- Status: review
-- Owner: reviewer
+- Status: done
+- Owner: implementer
 - Brief: .fas/tasks/fix-docs-site-discrepancies-from-2026-06-11-audit-supervisi.md
+- Verification lane: fast
+- Policy sensitivity: standard
+- Blast radius: cross-cutting
+
+### Task: Docs: refresh root + runtime READMEs to the real post-rename
+
+- Title: Docs: refresh root + runtime READMEs to the real post-rename
+- Mode: single-agent
+- Status: implementing
+- Owner: implementer
+- Brief: .fas/tasks/docs-refresh-root-runtime-readmes-to-the-real-post-rename.md
 - Verification lane: fast
 - Policy sensitivity: standard
 - Blast radius: cross-cutting

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ JavaScript lacks built-in primitives for actor-based concurrency and fault toler
 - **🌍 Location Transparency** - Actors work identically local or distributed
 - **🛡️ Fault Tolerance** - Supervisor trees with "let it crash" philosophy
 - **📦 Workspace Packages** - Runtime, testing utilities, and workflow CLI ship from `packages/*`
-- **🔄 Unified API** - Single `defineActor()` for all patterns
+- **🔄 Unified API** - Single `defineBehavior()` for all patterns
 
 ## ⚡ Quick Start
 
@@ -26,10 +26,10 @@ npm install @actor-web/runtime
 ```
 
 ```typescript
-import { createActorSystem, defineActor } from '@actor-web/runtime';
+import { createActorSystem, defineBehavior } from '@actor-web/runtime';
 
 // Define an actor with the unified API
-const counterActor = defineActor<{ type: 'INCREMENT' | 'GET_COUNT' }>()
+const counterActor = defineBehavior<{ type: 'INCREMENT' | 'GET_COUNT' }>()
   .withContext({ count: 0 })
   .onMessage(({ message, actor }) => {
     const { count } = actor.getSnapshot().context;
@@ -45,7 +45,7 @@ const counterActor = defineActor<{ type: 'INCREMENT' | 'GET_COUNT' }>()
         return { reply: { count } };
     }
   });
-  // Note: .build() is called automatically by the framework
+  // .build() is optional — the framework builds the behavior when you spawn it
 
 // Create and use the actor system
 const system = await createActorSystem({ nodeAddress: 'localhost:0' });
@@ -96,20 +96,20 @@ One API for all actor patterns - no need to choose between different builder typ
 
 ```typescript
 // Stateless actor (pure message router)
-const routerActor = defineActor<RouterMessage>()
+const routerActor = defineBehavior<RouterMessage>()
   .onMessage(({ message }) => {
     return { emit: [{ type: 'ROUTED', to: message.target }] };
   });
 
 // Stateful actor (with context)
-const accountActor = defineActor<AccountMessage>()
+const accountActor = defineBehavior<AccountMessage>()
   .withContext({ balance: 0 })
   .onMessage(({ message, actor }) => {
     // Handle deposits, withdrawals, etc.
   });
 
 // State machine actor (with XState)
-const orderActor = defineActor<OrderMessage>()
+const orderActor = defineBehavior<OrderMessage>()
   .withMachine(orderStateMachine)
   .onMessage(({ message, actor }) => {
     // Handle based on current state
@@ -163,24 +163,30 @@ await system.subscribe(actor, {
 
 ### 4. Supervision Trees
 
-Erlang-style fault tolerance:
+Erlang-style fault tolerance, declared in the topology:
 
 ```typescript
-// Define a supervisor declaratively (Erlang/Elixir OTP style)
-const supervisorBehavior = createSupervisor({
-  strategy: 'one-for-one',      // 'one-for-all' | 'rest-for-one'
-  children: [
-    { id: 'worker-1', behavior: workerBehavior },
-    { id: 'worker-2', behavior: workerBehavior },
-    { id: 'db-pool', behavior: databaseActor }
-  ],
-  maxRestarts: 3,
-  restartWindow: 60000  // 1 minute
-});
+import { actor, defineActorWebTopology, node, supervisor } from '@actor-web/runtime/topology';
 
-// Spawn the supervisor (which automatically starts all children)
-const supervisor = await system.spawn(supervisorBehavior, { 
-  id: 'main-supervisor' 
+const topology = defineActorWebTopology({
+  nodes: { local: node('local-node') },
+  actors: {
+    worker: actor({
+      id: 'worker',
+      node: 'local',
+      behavior: workerBehavior,
+      // Per-actor restart policy bounds crash loops
+      supervision: { strategy: 'restart', maxRestarts: 3, withinMs: 60_000 },
+    }),
+    dbPool: actor({ id: 'db-pool', node: 'local', behavior: databaseActor }),
+  },
+  supervisors: {
+    main: supervisor({
+      node: 'local',
+      strategy: 'one-for-one', // 'one-for-all' | 'rest-for-one' | 'escalate'
+      children: ['worker', 'dbPool'],
+    }),
+  },
 });
 ```
 
@@ -189,7 +195,7 @@ const supervisor = await system.spawn(supervisorBehavior, {
 ### State-Based Behavior (XState Integration)
 
 ```typescript
-const trafficLightActor = defineActor<{ type: 'TIMER' | 'EMERGENCY' }>()
+const trafficLightActor = defineBehavior<{ type: 'TIMER' | 'EMERGENCY' }>()
   .withMachine(trafficLightMachine)
   .onMessage(({ message, actor }) => {
     const snapshot = actor.getSnapshot();
@@ -213,7 +219,7 @@ const trafficLightActor = defineActor<{ type: 'TIMER' | 'EMERGENCY' }>()
 // This maintains actor isolation and enables location transparency
 
 // Create a database actor that manages its own connection pool
-const databaseActor = defineActor<
+const databaseActor = defineBehavior<
   | { type: 'QUERY'; sql: string; params?: any[] }
   | { type: 'INSERT'; table: string; data: Record<string, any> }
   | { type: 'INIT_POOL'; config: any }
@@ -349,14 +355,14 @@ console.log('Created user:', newUser);
 
 ```typescript
 // ❌ NEVER: Direct external calls in actors
-const myActor = defineActor()
+const myActor = defineBehavior()
   .onMessage(async ({ message }) => {
     await database.save(data);  // VIOLATION! Breaks actor isolation
     await fetch('/api/endpoint'); // VIOLATION! Not message-based
   });
 
 // ✅ CORRECT: Create dedicated actors for external systems
-const databaseActor = defineActor<{ type: 'SAVE'; data: any }>()
+const databaseActor = defineBehavior<{ type: 'SAVE'; data: any }>()
   .onMessage(async ({ message }) => {
     // This actor's sole responsibility is database interaction
     await database.save(message.data);
@@ -373,7 +379,7 @@ class MySingleton {
 }
 
 // ✅ CORRECT: State as actor context
-const cacheActor = defineActor<{ type: 'GET' | 'SET'; key: string; value?: any }>()
+const cacheActor = defineBehavior<{ type: 'GET' | 'SET'; key: string; value?: any }>()
   .withContext({ cache: new Map() })
   .onMessage(({ message, actor }) => {
     const { cache } = actor.getSnapshot().context;
@@ -393,14 +399,14 @@ const count = actor.getSnapshot().context.value;  // VIOLATION!
 const { value } = await actor.ask({ type: 'GET_VALUE' });
 
 // ❌ NEVER: Blocking operations
-const actor = defineActor()
+const actor = defineBehavior()
   .onMessage(({ message }) => {
     const result = someSyncBlockingOperation(); // VIOLATION!
     while (condition) { /* busy wait */ }       // VIOLATION!
   });
 
 // ✅ CORRECT: All operations must be async and message-based
-const actor = defineActor()
+const actor = defineBehavior()
   .onMessage(({ message }) => {
     // Delegate to another actor or return immediately
     return { emit: [{ type: 'PROCESS_ASYNC', data: message.data }] };

--- a/docs/API.md
+++ b/docs/API.md
@@ -109,6 +109,10 @@ const shipmentBehavior = defineBehavior()
   .build();
 ```
 
+`.build()` is optional everywhere it appears in this document — topology
+declarations and `system.spawn(...)` accept an un-built builder and build it
+for you. Examples here call it explicitly only to show the complete chain.
+
 Handler context:
 
 - `message`: incoming actor message.

--- a/packages/actor-core-runtime/README.md
+++ b/packages/actor-core-runtime/README.md
@@ -1,775 +1,96 @@
 # @actor-web/runtime
 
-## Pure Actor Model Runtime for Actor-Web Framework
+> **Pure actor model runtime for JavaScript/TypeScript** — location-transparent actors, supervision trees, and message-only communication, inspired by Erlang/OTP.
 
-### 100% Pure Actor Model Compliant
+**📚 Documentation: [0xjcf.github.io/actor-web](https://0xjcf.github.io/actor-web/)**
 
-This package provides the pure actor model implementation for the Actor-Web Framework, featuring advanced TypeScript design patterns for building resilient, scalable distributed systems with AI agent capabilities.
+## Install
 
-### 🚨 Migration Notice
-
-**This is the new pure actor runtime that replaces the legacy framework in `/src/core`.**
-
-The main framework (`/src/core`) contains architectural violations of the pure actor model:
-
-- Singleton patterns (ReactiveEventBus, GlobalEventDelegation)
-- Direct state access via `getSnapshot()`
-- Shared global state
-
-This package (`@actor-web/runtime`) implements the pure actor model correctly with advanced patterns:
-
-- ✅ **Pure Actor Model** - No singletons, message-only communication
-- ✅ **Capability Security** - Fine-grained permission-based access control
-- ✅ **Virtual Actor System** - Orleans-style caching with location transparency
-- ✅ **tRPC-Inspired Proxies** - Type-safe actor communication with zero boilerplate
-- ✅ **Supervisor Trees** - Hierarchical fault tolerance with "let it crash" philosophy
-- ✅ **AI Agent Patterns** - HTN planning, memory systems, and pipeline workflows
-
-### 🌟 Feature Highlights
-
-#### **Unified Actor API**
-
-- **Single `defineBehavior()` API** - One API for all actor patterns
-- **Three Actor Types** - Stateless, Context-based, Machine-based
-- **OTP Pattern Support** - Context updates, event emission, and replies
-- **Type Inference** - Full TypeScript support with proper context types
-
-#### **Test Synchronization Utilities**
-
-- **Test Mode** - Synchronous message processing for deterministic tests
-- **Flush Method** - Wait for all mailboxes to process
-- **Event Collectors** - Built-in test utilities for event verification
-- **No `setImmediate`** - Clean test code without timing hacks
-
-#### **Pure Actor Model**
-
-- **Message-Only Communication** - No shared state or direct method calls
-- **Location Transparency** - Actors work the same locally or distributed
-- **Auto-Publishing** - Events automatically routed to subscribers
-- **Direct Mailbox Enqueue** - No async boundaries for event delivery
-
-#### **Performance & Architecture**
-
-- **Orleans-Style Caching** - 90%+ cache hit rates
-- **Bounded Mailboxes** - Automatic backpressure handling
-- **Zero `any` Types** - Complete type safety without casting
-- **Cross-Environment** - Node.js/Browser/Worker support
-
-## ⚡ Quick Start
-
-```typescript
-import { createProxyActor, procedures } from '@actor-web/runtime';
-
-// 1. Define what your actor can do
-const chatRouter = {
-  sendMessage: procedures.mutation<{ text: string }, { id: string }>(),
-  getHistory: procedures.query<{ limit: number }, Message[]>(),
-  typing: procedures.subscription<{}, { isTyping: boolean }>()
-};
-
-// 2. One line creates actor + type-safe proxy
-const { actor, proxy: chat } = createProxyActor(chatMachine, chatRouter);
-actor.start();
-
-// 3. Use like regular async functions - zero boilerplate!
-const message = await chat.sendMessage({ text: 'Hello!' });
-const history = await chat.getHistory({ limit: 10 });
-chat.typing({}).subscribe(status => console.log(status));
+```bash
+npm install @actor-web/runtime
 ```
 
-That's it! No manual event handling, no correlation IDs, no boilerplate. Just pure type safety and simplicity.
-
-## Core APIs
-
-### Actor System
-
-```typescript
-import { createActorSystem } from '@actor-web/runtime';
-
-// Create and start the actor system
-const system = await createActorSystem({ nodeAddress: 'localhost:0' });
-await system.start();
-
-// Spawn actors
-const counter = await system.spawn(counterActor, { id: 'counter-1' });
-
-// Send messages
-await counter.send({ type: 'INCREMENT' });
-
-// Ask pattern (request/response)
-const count = await counter.ask({ type: 'GET_COUNT' });
-
-// Subscribe to events
-await system.subscribe(counter, { 
-  subscriber: logger,
-  events: ['COUNT_CHANGED']
-});
-
-// Test utilities
-system.enableTestMode();  // Synchronous processing
-await system.flush();     // Wait for all messages
-```
-
-### Defining Actors
-
-```typescript
-import { defineBehavior } from '@actor-web/runtime';
-
-// Define message types
-type CounterMessage = 
-  | { type: 'INCREMENT' }
-  | { type: 'DECREMENT' }
-  | { type: 'GET_COUNT' }
-  | { type: 'RESET'; value: number };
-
-// Define actor with OTP patterns
-const counterActor = defineBehavior<CounterMessage>()
-  .withContext({ count: 0 })
-  .onMessage(({ message, actor }) => {
-    const { count } = actor.getSnapshot().context;
-    
-    switch (message.type) {
-      case 'INCREMENT':
-        // Update context and emit event
-        return {
-          context: { count: count + 1 },
-          emit: [{ 
-            type: 'COUNT_CHANGED', 
-            oldValue: count, 
-            newValue: count + 1 
-          }]
-        };
-        
-      case 'GET_COUNT':
-        // Reply to ask pattern
-        return {
-          reply: { value: count }
-        };
-        
-      case 'RESET':
-        // Update context with new value
-        return {
-          context: { count: message.value },
-          emit: [{ 
-            type: 'COUNT_RESET', 
-            newValue: message.value 
-          }]
-        };
-    }
-  });
-```
-
-### OTP Handler Patterns
-
-#### Context Updates
-
-```typescript
-// Return new context to update actor state
-return {
-  context: { count: newCount, lastUpdated: Date.now() }
-};
-```
-
-#### Event Emission
-
-```typescript
-// Emit events that subscribers will receive
-return {
-  emit: [
-    { type: 'STATE_CHANGED', data: newState },
-    { type: 'METRIC_UPDATED', metric: 'count', value: newCount }
-  ]
-};
-```
-
-#### Reply to Ask Pattern
-
-```typescript
-// Reply directly to ask() calls
-return {
-  reply: { status: 'success', data: result }
-};
-
-// Reply with context update
-return {
-  context: { processed: true },
-  reply: { id: generatedId, timestamp: Date.now() }
-};
-```
-
-#### State-Based Behavior (XState Machines)
-
-**When to use `state.matches` vs `message.type`:**
-
-- **`message.type`** - For deciding what action to take based on incoming message
-- **`state.matches`** - For conditional behavior based on actor's current state
-
-```typescript
-const orderActor = defineBehavior<OrderMessage>()
-  .withMachine(orderMachine)
-  .onMessage(({ message, actor }) => {
-    const snapshot = actor.getSnapshot();
-    
-    // First, handle based on message type
-    switch (message.type) {
-      case 'SUBMIT_ORDER':
-        // Then check state to decide if action is valid
-        if (snapshot.matches('draft')) {
-          return {
-            emit: [{ type: 'ORDER_SUBMITTED', orderId: snapshot.context.orderId }]
-          };
-        } else {
-          return {
-            emit: [{ type: 'INVALID_ACTION', reason: 'Order already submitted' }]
-          };
-        }
-        
-      case 'CANCEL_ORDER':
-        // Different behavior based on current state
-        if (snapshot.matches('processing')) {
-          return {
-            emit: [{ type: 'CANCELLATION_REQUESTED' }]
-          };
-        } else if (snapshot.matches('shipped')) {
-          return {
-            reply: { error: 'Cannot cancel shipped orders' }
-          };
-        }
-        break;
-    }
-  });
-```
-
-#### Pure Actor Model Clarification
-
-**Important:** This framework strictly follows the pure actor model. All communication must be through messages.
-
-**Important:** In Erlang/Elixir OTP, there is no concept of "effects". Everything is handled through message passing. Following this principle, we have removed the `effects` field from our framework to maintain pure actor model compliance.
-
-```typescript
-
-// ✅ CORRECT: Use standard OTP patterns - just emit messages
-return {
-  // Simple and clean - just like Erlang/Elixir
-  emit: [
-    { type: 'SAVE_DATA_REQUESTED', data },
-    { type: 'EMAIL_REQUESTED', email }
-  ]
-};
-
-// ✅ CORRECT: Update context and emit events (standard OTP pattern)
-return {
-  context: { count: newCount },
-  emit: [
-    { type: 'COUNT_CHANGED', oldValue, newValue }
-  ]
-};
-
-// ✅ CORRECT: Reply to ask patterns
-return {
-  reply: { status: 'success', data: result }
-};
-```
-
-**Following Erlang/Elixir Patterns:**
-In Erlang/Elixir, gen_server callbacks return tuples like:
-
-- `{:reply, reply, new_state}` - Reply and update state
-- `{:noreply, new_state}` - Just update state
-- `{:stop, reason, new_state}` - Stop the actor
-
-Our framework mirrors this with:
-
-- `{ reply, context }` - Reply and update context
-- `{ context }` - Just update context  
-- `{ emit, context }` - Update context and broadcast events
-
-**Keep It Simple:**
-
-- Use `context` to update actor state
-- Use `reply` to respond to ask patterns
-- Use `emit` to broadcast events to subscribers
-- Avoid `effects` - it's not part of the pure actor model
-
-```typescript
-return {
-  // Broadcast to all subscribers
-  emit: [
-    { type: 'ORDER_COMPLETED', orderId, total }
-  ],
-  
-  // Send specific messages to known actors
-  effects: [
-    { to: inventoryActor, tell: { type: 'REDUCE_STOCK', items } },
-    { to: shippingActor, tell: { type: 'SCHEDULE_DELIVERY', orderId } }
-  ]
-};
-```
-
-## Usage Examples
-
-### Complete Banking Example
+## Quick start
 
 ```typescript
 import { createActorSystem, defineBehavior } from '@actor-web/runtime';
 
-// Define a bank account actor
-type AccountMessage = 
-  | { type: 'DEPOSIT'; amount: number }
-  | { type: 'WITHDRAW'; amount: number }
-  | { type: 'GET_BALANCE' }
-  | { type: 'TRANSFER'; to: string; amount: number };
-
-const accountActor = defineBehavior<AccountMessage>()
-  .withContext({ 
-    balance: 0, 
-    transactions: []
-  })
+const counter = defineBehavior<{ type: 'INCREMENT' | 'GET_COUNT' }>()
+  .withContext({ count: 0 })
   .onMessage(({ message, actor }) => {
-    const { balance, transactions } = actor.getSnapshot().context;
-    
-    switch (message.type) {
-      case 'DEPOSIT':
-        return {
-          context: {
-            balance: balance + message.amount,
-            transactions: [...transactions, { 
-              type: 'DEPOSIT', 
-              amount: message.amount,
-              timestamp: Date.now()
-            }]
-          },
-          emit: [{ 
-            type: 'TRANSACTION_COMPLETED', 
-            transactionType: 'DEPOSIT',
-            amount: message.amount,
-            newBalance: balance + message.amount
-          }]
-        };
-        
-      case 'WITHDRAW':
-        if (balance < message.amount) {
-          return {
-            reply: { error: 'INSUFFICIENT_FUNDS' },
-            emit: [{ 
-              type: 'WITHDRAWAL_FAILED', 
-              requested: message.amount, 
-              available: balance 
-            }]
-          };
-        }
-        return {
-          context: {
-            balance: balance - message.amount,
-            transactions: [...transactions, { 
-              type: 'WITHDRAW', 
-              amount: message.amount,
-              timestamp: Date.now()
-            }]
-          },
-          reply: { success: true, newBalance: balance - message.amount },
-          emit: [{ 
-            type: 'TRANSACTION_COMPLETED',
-            transactionType: 'WITHDRAW', 
-            amount: message.amount,
-            newBalance: balance - message.amount
-          }]
-        };
-        
-      case 'GET_BALANCE':
-        return {
-          reply: { 
-            balance, 
-            transactionCount: transactions.length,
-            lastTransaction: transactions[transactions.length - 1]
-          }
-        };
-    }
-  });
+    const { count } = actor.getSnapshot().context;
 
-// Usage
-const system = await createActorSystem({ nodeAddress: 'localhost:0' });
-const account = await system.spawn(accountActor, { id: 'account-123' });
-
-// Subscribe to events
-const auditor = await system.spawnEventCollector();
-await system.subscribe(account, {
-  subscriber: auditor,
-  events: ['TRANSACTION_COMPLETED', 'WITHDRAWAL_FAILED']
-});
-
-// Make transactions
-await account.send({ type: 'DEPOSIT', amount: 100 });
-const withdrawResult = await account.ask({ type: 'WITHDRAW', amount: 50 });
-console.log('Withdraw result:', withdrawResult); // { success: true, newBalance: 50 }
-
-// Check balance
-const { balance } = await account.ask({ type: 'GET_BALANCE' });
-console.log('Current balance:', balance); // 50
-```
-
-### Testing with Synchronization
-
-```typescript
-import { defineBehavior, createActor } from '@actor-web/runtime';
-import { setup, assign } from 'xstate';
-
-// Define XState machine for state management
-const counterMachine = setup({
-  types: {
-    context: {} as { count: number },
-    events: {} as { type: 'INCREMENT' } | { type: 'GET_COUNT' }
-  },
-  actions: {
-    increment: assign({ count: ({ context }) => context.count + 1 })
-  }
-}).createMachine({
-  initial: 'active',
-  context: { count: 0 },
-  states: {
-    active: {
-      on: {
-        INCREMENT: { actions: 'increment' },
-        GET_COUNT: { actions: 'increment' }
-      }
-    }
-  }
-});
-
-// Define pure actor behavior using unified API
-const counterBehavior = defineBehavior({
-  onMessage: async ({ message, actor, dependencies }) => {
-    const currentState = actor.getSnapshot();
-    
     switch (message.type) {
       case 'INCREMENT':
-        actor.send({ type: 'INCREMENT' });
         return {
-          type: 'COUNTER_INCREMENTED',
-          payload: { newValue: currentState.context.count + 1 },
-          timestamp: Date.now(),
-          version: '1.0.0'
+          context: { count: count + 1 },
+          emit: [{ type: 'COUNT_CHANGED', newValue: count + 1 }],
         };
-        
       case 'GET_COUNT':
-        if (message.correlationId) {
-          return {
-            type: 'COUNT_RESULT',
-            correlationId: message.correlationId,
-            payload: currentState.context.count,
-            timestamp: Date.now(),
-            version: '1.0.0'
-          };
-        }
-        break;
+        return { reply: { count } };
     }
-    return undefined;
-  }
-});
+  });
+// .build() is optional — the framework builds the behavior when you spawn it
 
-// Create and use actor with unified API
-// Create and spawn the actor
-const counter = await system.spawn(counterActor, { id: 'counter' });
+const system = await createActorSystem({ nodeAddress: 'localhost:0' });
+await system.start();
 
-// Pure actor model - message-only communication
-await counter.send({ type: 'INCREMENT' });
-const count = await counter.ask({ type: 'GET_COUNT' });
-console.log('Count:', count.value); // 1
+const ref = await system.spawn(counter, { id: 'counter-1' });
+await ref.send({ type: 'INCREMENT' });
+const { count } = await ref.ask({ type: 'GET_COUNT' });
 ```
 
-#### **Zero-Boilerplate Actor Proxies**
-
-```typescript
-import { createProxyActor, procedures } from '@actor-web/runtime';
-
-// Define router with type safety
-const userRouter = {
-  getUser: procedures.query<{ id: string }, User>(),
-  createUser: procedures.mutation<CreateUserInput, User>(),
-  userUpdates: procedures.subscription<{ userId: string }, UserUpdate>()
-};
-
-// One-liner: actor + type-safe proxy
-const { actor, proxy: users } = createProxyActor(userMachine, userRouter);
-actor.start();
-
-// Use like regular async functions - zero boilerplate!
-const user = await users.getUser({ id: '123' });
-const newUser = await users.createUser({ name: 'Alice', email: 'alice@example.com' });
-
-// Type-safe subscriptions
-const subscription = users.userUpdates({ userId: '123' });
-subscription.subscribe(update => console.log('User updated:', update));
-```
-
-#### **Instant Capability Security**
-
-```typescript
-import { createCapabilitySecuredRef } from '@actor-web/runtime';
-
-// Secure any actor in one line
-const securedActor = createCapabilitySecuredRef(actor, {
-  permissions: ['read', 'write:config'],
-  timeLimit: 300000, // 5 minutes
-});
-
-// Automatic validation - no boilerplate
-await securedActor.ask({ type: 'READ_DATA' }); // ✅ 
-await securedActor.ask({ type: 'DELETE_ALL' }); // ❌ Auto-rejected
-```
-
-#### **Orleans-Style Virtual Actors**
-
-```typescript
-import { createVirtualActorRef } from '@actor-web/runtime';
-
-// Auto-cached actors with lifecycle management
-const userActor = createVirtualActorRef('user', userId, userBehavior);
-
-// Automatic activation/deactivation - zero configuration
-const userData = await userActor.ask({ type: 'GET_PROFILE' });
-```
-
-#### **Bulletproof Supervisor Trees**
-
-```typescript
-import { createSupervisorTree } from '@actor-web/runtime';
-
-// Fault tolerance in 5 lines
-const supervisor = createSupervisorTree({
-  strategy: 'one-for-one',
-  children: [
-    { id: 'worker-1', behavior: workerBehavior },
-    { id: 'worker-2', behavior: workerBehavior }
-  ]
-});
-
-supervisor.start(); // Workers auto-restart on failure
-```
-
-#### **Smart AI Planning (HTN)**
-
-```typescript
-import { createHTNPlanner } from '@actor-web/runtime';
-
-// Intelligent task decomposition
-const planner = createHTNPlanner();
-
-// Register behaviors once
-planner.registerTask('move-book-to-shelf', moveBookBehavior);
-
-// AI generates optimal plans automatically
-const plan = await planner.generatePlan({
-  goals: ['book-on-shelf'],
-  worldState: { robotLocation: 'living_room', bookLocation: 'table' }
-});
-
-// Execute with full actor integration
-const result = await planner.executePlan(plan);
-```
-
-#### **Composable AI Pipelines**
-
-```typescript
-import { createPipeline, createActorStage } from '@actor-web/runtime';
-
-// Build AI workflows with actors
-const aiPipeline = createPipeline({ name: 'content-processor' })
-  .stage('analyze', createActorStage({ actor: analyzerActor }))
-  .stage('summarize', createActorStage({ actor: summarizerActor }));
-
-// Execute with automatic retry and error handling
-const result = await aiPipeline.execute(inputText);
-```
-
-#### **Intelligent Memory System**
-
-```typescript
-import { createAgentMemory, createExperience } from '@actor-web/runtime';
-
-// Three-layer memory: cache + vectors + knowledge graph
-const memory = createAgentMemory();
-
-// Store and auto-index experiences
-await memory.remember(createExperience(
-  'User prefers concise explanations',
-  { importance: 0.9, tags: ['user-preference'] }
-));
-
-// Smart query across all layers
-const memories = await memory.recall('user communication preferences');
-
-// Context-aware decision making
-const decision = analyzeMemoriesForDecision(memories);
-```
-
-### Design Principles
-
-1. **Message-Only Communication**: Actors communicate exclusively through asynchronous messages
-2. **Location Transparency**: Actor references work regardless of actor location
-3. **Supervision**: Hierarchical fault tolerance with "let it crash" philosophy
-4. **No Shared State**: Each actor has isolated state, no global singletons
-5. **Type Safety**: Complete TypeScript coverage without `any` types
-6. **Capability Security**: Fine-grained permission-based access control
-7. **Performance**: Sub-millisecond actor lookup with intelligent caching
-
-### Architecture Overview
-
-```text
-@actor-web/runtime
-├── 🎭 Core Actor System
-│   ├── actor-ref.ts              # Basic actor references
-│   ├── create-actor-ref.ts       # Actor factory functions
-│   ├── messaging/                # Message transport and correlation
-│   └── types.ts                  # Core type definitions
-├── 🔒 Security & Access Control
-│   ├── capability-security.ts    # Permission-based access
-│   └── virtual-actors.ts         # Orleans-style virtual actors
-├── 🚀 Developer Experience
-│   ├── actor-proxy.ts            # tRPC-inspired type-safe proxies
-│   ├── runtime-adapter.ts        # Cross-environment support
-│   └── logger.ts                 # Enhanced debugging
-├── 🧠 AI Agent Patterns
-│   ├── planning/                 # Hierarchical Task Networks
-│   ├── memory/                   # Hybrid memory architecture
-│   ├── patterns/                 # Pipeline workflows
-│   └── actors/                   # Supervisor trees
-└── 📖 Examples & Documentation
-    ├── examples/                 # Comprehensive usage examples
-    └── README.md                 # This file
-```
-
-### Performance Characteristics
-
-- **Actor Lookup**: Sub-millisecond with 90%+ cache hit rate
-- **Message Throughput**: 10,000+ messages/second per actor
-- **Memory Usage**: Bounded mailboxes with automatic backpressure
-- **Fault Recovery**: Automatic supervisor restart within 100ms
-- **Type Checking**: Zero runtime overhead with compile-time validation
-
-### Testing Patterns
-
-```typescript
-import { createEventCollectorBehavior } from '@actor-web/runtime';
-
-// Enable test mode for deterministic behavior
-system.enableTestMode();
-
-const counter = await system.spawn(counterActor);
-const collector = await system.spawn(createEventCollectorBehavior());
-
-// Subscribe to events
-await system.subscribe(counter, {
-  subscriber: collector,
-  events: ['COUNT_CHANGED']
-});
-
-// Messages are processed synchronously in test mode
-await counter.send({ type: 'INCREMENT' });
-// No need to wait - message already processed!
-
-const events = await collector.ask({ type: 'GET_EVENTS' });
-expect(events.collectedEvents).toHaveLength(1);
-expect(events.collectedEvents[0]).toMatchObject({
-  type: 'COUNT_CHANGED',
-  oldValue: 0,
-  newValue: 1
-});
-
-// Alternative: Use flush() for specific synchronization
-system.disableTestMode();
-await counter.send({ type: 'INCREMENT' });
-await counter.send({ type: 'INCREMENT' });
-await system.flush(); // Wait for all messages to process
-
-const finalCount = await counter.ask({ type: 'GET_COUNT' });
-expect(finalCount.value).toBe(3);
-```
-
-### Development Workflow
-
-```bash
-# Install dependencies
-pnpm install
-
-# Run all tests with logging
-pnpm test
-
-# Run specific pattern examples
-pnpm test -- --run src/examples/hybrid-memory-example.test.ts
-pnpm test -- --run src/examples/pipeline-example.test.ts
-pnpm test -- --run src/examples/htn-planner-example.test.ts
-
-# Build with type checking
-pnpm build
-
-# Type check only
-pnpm typecheck
-
-# Run examples directly
-node dist/examples/hybrid-memory-example.js
-```
-
-### Advanced Patterns Guide
-
-#### **Error Handling Strategies**
-
-```typescript
-// Supervisor with custom restart logic
-const supervisor = createSupervisorTree({
-  strategy: RestartStrategy.ONE_FOR_ALL,
-  maxRestarts: 5,
-  restartWindow: 30000,
-  onFailure: async (child, error) => {
-    await logger.error('Child failed', { child: child.id, error });
-    await notificationActor.send({ type: 'ALERT', error });
-  }
-});
-```
-
-#### **Performance Monitoring**
-
-```typescript
-// Built-in performance metrics
-const metrics = await actor.ask({ type: 'GET_METRICS' });
-console.log({
-  messageRate: metrics.messagesPerSecond,
-  queueSize: metrics.mailboxSize,
-  averageResponseTime: metrics.avgResponseTime
-});
-```
-
-#### **Cross-Environment Deployment**
-
-```typescript
-// Automatic environment detection
-const adapter = createRuntimeAdapter({
-  environment: 'auto', // Detects Node.js/Browser/Worker
-  transport: 'websocket', // Falls back to MessageChannel
-  clustering: true // Enables worker threads
-});
-```
-
-### Contributing
-
-This package implements cutting-edge patterns for distributed AI systems. Areas for contribution:
-
-- **Transport Layers**: WebSocket and Worker message transport
-- **Testing Patterns**: Property-based and generative testing
-- **Debugging Tools**: Time-travel debugging and distributed tracing
-- **Performance**: Micro-optimizations and benchmarking
-- **Documentation**: More examples and integration guides
-
-### Research & Inspiration
-
-This implementation draws from:
-
-- **Microsoft Orleans** - Virtual actor model and lifecycle management
-- **Erlang/OTP** - Supervisor trees and "let it crash" philosophy
-- **tRPC** - Type-safe API design patterns
-- **Akka** - Message-driven architecture
-- **Modern AI Research** - HTN planning and hybrid memory systems
-
-### License
+For multi-actor applications, declare a topology and let the runtime own
+placement, lifecycle, supervision, and event wiring — see
+[Topology & local runtime](https://0xjcf.github.io/actor-web/getting-started/topology-and-runtime).
+
+## Entry points
+
+| Import | Use for |
+| --- | --- |
+| `@actor-web/runtime` | `defineBehavior`, `createActorSystem`, message-plan types, testing hooks |
+| `@actor-web/runtime/topology` | `defineActorWebTopology`, `actor`, `node`, `supervisor`, `tool` — declarative, import-safe topology definitions |
+| `@actor-web/runtime/node` | `serveNode`, `serveActorWebHttp` — host a topology node in Node.js with WebSocket transport and gateway |
+| `@actor-web/runtime/browser` | `startActorWebNode`, `createActorWebClient`, `createActorWebReadModelClient` — browser/worker nodes and gateway clients |
+
+## What you get
+
+- **Unified behavior builder** — one `defineBehavior()` API for stateless,
+  context-based, and XState-machine actors, with full type inference from
+  message unions through to UI sources.
+- **OTP-style handler returns** — `{ context, reply, emit }`: update state,
+  answer an `ask`, broadcast domain events to subscribers.
+- **Topology-declared runtime** — declare nodes, actors, supervisors, and
+  inter-actor `subscriptions` once; the runtime wires them on every start.
+- **Supervision trees** — `one-for-one` / `one-for-all` / `rest-for-one` /
+  `escalate` strategies with bounded restart policies ("let it crash").
+- **Bounded mailboxes** — FIFO per-actor processing with configurable
+  backpressure (drop, park, or fail on overflow).
+- **Tool ports** — actors declare the capabilities they need; concrete
+  adapters are injected at the runtime boundary via a per-actor allow-list,
+  keeping behavior logic free of direct I/O.
+- **Transports & gateway** — WebSocket transports for Node and browser nodes,
+  plus a projection gateway for UI read models and commands.
+- **Test utilities** — `system.enableTestMode()`, `system.flush()`, and
+  event-collector actors for deterministic tests without timing hacks.
+
+## Delivery semantics (read this)
+
+Message delivery is **at-most-once**: a send enqueues to the target mailbox
+once and is never retried or acknowledged by the runtime. Per-actor ordering
+is FIFO. For request/response confirmation use `ask` with a timeout; for
+stronger guarantees build an application-level acknowledgement protocol.
+Actor restarts begin from the behavior's initial context — durable state
+belongs in external stores, re-derived in `onStart`.
+
+## Part of Actor-Web
+
+This package is the runtime for the
+[Actor-Web framework](https://github.com/0xjcf/actor-web). Companion packages:
+
+- [`@actor-web/testing`](https://www.npmjs.com/package/@actor-web/testing) —
+  machine analysis and test helpers.
+
+## License
 
 MIT


### PR DESCRIPTION
## Summary

Second of the three queued audit tasks (brief: docs-refresh-root-runtime-readmes; 2026-06-10 audit, re-verified 2026-06-11).

**Root README.md**
- All 13 `defineActor()` uses renamed to `defineBehavior` (the actual export since the 2026-06-09 rename — `defineActor` is not exported)
- The `createSupervisor()` example (no such export) replaced with the topology `supervisor()` DSL — same style the docs site teaches
- `.build()` optionality stated once; added docs badge/link in a prior PR

**packages/actor-core-runtime/README.md** (ships in the npm tarball — renders on npmjs.com at next publish)
- Rewritten 775 → ~110 lines to the shipped surface. The old page's Quick Start used `createProxyActor`/`procedures` (not exported), and the feature list claimed an Orleans-style Virtual Actor System, tRPC-inspired proxies, HTN planning, and 'Capability Security' (the real mechanism is the topology toolAccess allow-list) — none provable from source. It also carried a '/src/core migration notice' referencing a directory that doesn't exist in this repo.
- New page: real entry points table (`.`, `/topology`, `/node`, `/browser` per the package export map), features that are all backed by source, an explicit **at-most-once delivery semantics** section, and links to the live docs site.

**docs/API.md**
- `.build()` optionality stated once; the reference keeps explicit `.build()` in examples to show the complete chain. (Ignite-naming mentions deliberately untouched — separate queued task's scope.)

## Verification

- `markdownlint-cli2` clean on all three files (run manually — markdown outside .fas/ is not verify-linted, per the brief's reminder)
- `.fas/scripts/verify.sh --full` ALL PASSED; `fas validate-task` plan alignment fully clean
- Every API named in the rewritten pages was grep-verified against `packages/actor-core-runtime/src/index.ts` exports

Note: the npm page for @actor-web/runtime updates at the next publish (tied to the queued release-prep 0.2.0 task).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated examples to emphasize the unified actor API approach across multiple sections.
  * Clarified that `.build()` is optional when using behavior builders in topology declarations and system spawning.
  * Comprehensively refreshed runtime package documentation with focused API guide, quick start examples, package entry points, and delivery semantics.
  * Enhanced supervision configuration and anti-pattern examples for improved developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->