### PR TITLE
feat: opaque actor addresses via one canonical factory (L0)

### DIFF
--- a/.changeset/opaque-actor-addresses.md
+++ b/.changeset/opaque-actor-addresses.md
@@ -1,0 +1,11 @@
+---
+'@actor-web/runtime': minor
+---
+
+Make actor addresses opaque and mint them through one canonical factory.
+
+- `ActorAddress.type: string` is now `kind: 'actor' | 'callback'`.
+- Actor address paths drop the redundant `/actor/` segment: an actor is now `actor://<node>/<id>` (callback addresses keep `actor://<node>/callback/<id>`).
+- All actor addresses are minted through a single pure factory `createActorAddress(id, node?, kind?)` with one canonical local-node normalization — `node` is always set and `'local'` is the canonical marker. `createLocalActorAddress(id)` and `createRemoteActorAddress(id, node)` drop their former `type` parameter.
+
+**Breaking:** the exported `ActorAddress` / `ActorWebActorAddress` types, the `createActorAddress` signature, and the actor address path format have changed. All nodes in a cluster must upgrade together — the actor address wire format is not interoperable across this change (callback addresses are unaffected).

--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1624,10 +1624,13 @@
 ### Task: Make actor addresses opaque and mint them through one canonical factory
 
 - Title: Make actor addresses opaque and mint them through one canonical factory
-- Mode: single-agent
-- Status: queued
-- Owner: runtime
+- Mode: 6-agent
+- Status: review
+- Owner: reviewer
 - Brief: .fas/tasks/make-actor-addresses-opaque-and-mint-them-through-one-canoni.md
+- Verification lane: fast
+- Policy sensitivity: standard
+- Blast radius: cross-cutting
 
 ### Task: Unify actor location truth: single directory-backed resolution for send and emit/subscribe
 

--- a/.fas/TASKS.md
+++ b/.fas/TASKS.md
@@ -1558,8 +1558,11 @@
 - Title: Implement @actor-web/transport-broadcast-channel adapter
 - Mode: single-agent
 - Status: queued
-- Owner: runtime
+- Owner: implementer
 - Brief: .fas/tasks/implement-actor-web-transport-broadcast-channel-adapter.md
+- Verification lane: fast
+- Policy sensitivity: standard
+- Blast radius: cross-cutting
 
 ### Task: Implement @actor-web/transport-webrtc peer adapter
 
@@ -1617,6 +1620,79 @@
 - Status: queued
 - Owner: runtime
 - Brief: .fas/tasks/grow-definetransport-into-a-smart-pipe-authoring-api-async-h.md
+
+### Task: Make actor addresses opaque and mint them through one canonical factory
+
+- Title: Make actor addresses opaque and mint them through one canonical factory
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/make-actor-addresses-opaque-and-mint-them-through-one-canoni.md
+
+### Task: Unify actor location truth: single directory-backed resolution for send and emit/subscribe
+
+- Title: Unify actor location truth: single directory-backed resolution for send and emit/subscribe
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/unify-actor-location-truth-single-directory-backed-resolutio.md
+
+### Task: Example: declarative topology.subscriptions through a directory-backed runtime
+
+- Title: Example: declarative topology.subscriptions through a directory-backed runtime
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/example-declarative-topology-subscriptions-through-a-directo.md
+- Automation mode: advisory
+
+### Task: Author the @actor-web/labs-mesh design doc (gossip membership, multi-hop, directory propagation)
+
+- Title: Author the @actor-web/labs-mesh design doc (gossip membership, multi-hop, directory propagation)
+- Mode: 6-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/author-the-actor-web-labs-mesh-design-doc-gossip-membership-.md
+
+### Task: Transport: large-payload framing/chunking contract or explicit max-payload with blob-externalization
+
+- Title: Transport: large-payload framing/chunking contract or explicit max-payload with blob-externalization
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/transport-large-payload-framing-chunking-contract-or-explici.md
+
+### Task: Agent transport: stream tool/agent output as a backpressured cross-node stream
+
+- Title: Agent transport: stream tool/agent output as a backpressured cross-node stream
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/agent-transport-stream-tool-agent-output-as-a-backpressured-.md
+
+### Task: Delivery semantics: at-least-once and idempotency for non-idempotent agent tool side-effects
+
+- Title: Delivery semantics: at-least-once and idempotency for non-idempotent agent tool side-effects
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/delivery-semantics-at-least-once-and-idempotency-for-non-ide.md
+
+### Task: Docs honesty pass: scope the location-transparency claim at first mention and reconcile multi-machine status
+
+- Title: Docs honesty pass: scope the location-transparency claim at first mention and reconcile multi-machine status
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/docs-honesty-pass-scope-the-location-transparency-claim-at-f.md
+
+### Task: Post-mesh scoping: membership graduation tier, cross-node supervision boundary, claim gating
+
+- Title: Post-mesh scoping: membership graduation tier, cross-node supervision boundary, claim gating
+- Mode: single-agent
+- Status: queued
+- Owner: runtime
+- Brief: .fas/tasks/post-mesh-scoping-membership-graduation-tier-cross-node-supe.md
 
 ## Template
 

--- a/.fas/tasks/agent-transport-stream-tool-agent-output-as-a-backpressured-.md
+++ b/.fas/tasks/agent-transport-stream-tool-agent-output-as-a-backpressured-.md
@@ -1,17 +1,16 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Agent transport: stream tool/agent output as a backpressured cross-node stream
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L5 (agent-payload gap, UNOWNED). emit is discrete and cross-node forwarding is per-event, not a backpressured stream. LLM agents stream tokens and tool output. Add a first-class backpressured stream primitive over the transport for agent/tool output across nodes. Depends on the large-payload framing contract.
 
 ## Acceptance criteria
 
-- The new functionality works as described.
-- Existing behavior is not broken.
+- The change is verified and does not introduce regressions.
 - TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
 - TDD: every production code change in the change set is covered by an added or updated test.
 - DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.

--- a/.fas/tasks/author-the-actor-web-labs-mesh-design-doc-gossip-membership-.md
+++ b/.fas/tasks/author-the-actor-web-labs-mesh-design-doc-gossip-membership-.md
@@ -1,17 +1,16 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Author the @actor-web/labs-mesh design doc (gossip membership, multi-hop, directory propagation)
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L3. The labs-mesh implementation brief is a content-free stub. Author the design first: gossip membership protocol, cluster-wide directory propagation (anti-entropy vs CRDT), multi-hop routing via the next-hop hook, liveness/node-monitor model, partition handling. This is the EPMD/net_kernel analog actor-web lacks (cross-node directory fill broadcastRegister/Unregister/Lookup are TODO no-op stubs in distributed-actor-directory.ts:447-479). Gates the membership/cluster layer.
 
 ## Acceptance criteria
 
-- The new functionality works as described.
-- Existing behavior is not broken.
+- The change is verified and does not introduce regressions.
 - TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
 - TDD: every production code change in the change set is covered by an added or updated test.
 - DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.

--- a/.fas/tasks/build-mesh-pong-example-ui-demo-headless-transport-parity.md
+++ b/.fas/tasks/build-mesh-pong-example-ui-demo-headless-transport-parity.md
@@ -1,4 +1,4 @@
-# Build Mesh Pong example (UI demo + headless transport-parity
+# Build Mesh Pong example (UI demo + headless transport-parity test)
 
 ## Source
 

--- a/.fas/tasks/delivery-semantics-at-least-once-and-idempotency-for-non-ide.md
+++ b/.fas/tasks/delivery-semantics-at-least-once-and-idempotency-for-non-ide.md
@@ -1,17 +1,16 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Delivery semantics: at-least-once and idempotency for non-idempotent agent tool side-effects
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L5 (agent-payload gap, UNOWNED). Application sends are at-most-once (runtime README:77-84); silently dropping a non-idempotent tool side-effect (write file, open PR, send email) is a correctness bug not latency. Add protocol-level ack plus timeout-re-emit plus idempotent activation IDs for side-effecting agent tool calls. Builds on the at-most-once delivery contract.
 
 ## Acceptance criteria
 
-- The new functionality works as described.
-- Existing behavior is not broken.
+- The change is verified and does not introduce regressions.
 - TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
 - TDD: every production code change in the change set is covered by an added or updated test.
 - DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.

--- a/.fas/tasks/docs-honesty-pass-scope-the-location-transparency-claim-at-f.md
+++ b/.fas/tasks/docs-honesty-pass-scope-the-location-transparency-claim-at-f.md
@@ -1,17 +1,16 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Docs honesty pass: scope the location-transparency claim at first mention and reconcile multi-machine status
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L6. (1) Hero one-liners (README:3,17,76; packages/actor-core-runtime/README.md:3; docs/site/index.md:7) assert distributed and location-transparent flatly; add a first-mention qualifier (across directly-connected nodes; dynamic membership in progress) linking the external-transport status doc. (2) Refresh README:67 (now stale-in-favor: identity/auth/replay/telemetry partly landed). (3) Reconcile the multi-machine prove-out contradiction: TASKS.md:535 done vs external-transport-design.md:204 remaining; state precisely what was proven (multi-process on one host) vs not (true multi-host).
 
 ## Acceptance criteria
 
-- The new functionality works as described.
-- Existing behavior is not broken.
+- The change is verified and does not introduce regressions.
 - TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
 - TDD: every production code change in the change set is covered by an added or updated test.
 - DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.

--- a/.fas/tasks/example-declarative-topology-subscriptions-through-a-directo.md
+++ b/.fas/tasks/example-declarative-topology-subscriptions-through-a-directo.md
@@ -1,17 +1,24 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Example: declarative topology.subscriptions through a directory-backed runtime
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L0. The declarative emit/subscribe path is under-exercised through a directory-backed runtime (fas-agent-loop uses imperative ask/send and declares no subscriptions), which is why the fas-studio dead-letter was caught by a consumer not the framework. Add a framework example exercising declarative topology.subscriptions cross-actor through the directory-backed local runtime, asserting clean delivery. Closes the test-gap behind the unify-location-truth fix.
+
+## Automation admission
+
+- Expected operator value: Improves operator leverage around "Example: declarative topology.subscriptions through a directory-backed runtime" by reducing manual coordination, repetitive execution, or trust gaps.
+- Observability surface: Use authoritative FAS surfaces such as `fas runtime status`, `fas runtime watch`, workflow logs, receipts, or notifications to show whether the automation is active, quiet, stalled, blocked, or complete.
+- Recovery path: A human can abort, retry, recover, or rerun this workflow without leaving stale queue, lease, branch, or current-task state.
+- Autonomy mode: advisory
+- Promotion criteria: Promote beyond advisory only after dogfood runs prove clear operator value, trustworthy observability, and bounded recovery.
 
 ## Acceptance criteria
 
-- The new functionality works as described.
-- Existing behavior is not broken.
+- The change is verified and does not introduce regressions.
 - TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
 - TDD: every production code change in the change set is covered by an added or updated test.
 - DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.

--- a/.fas/tasks/implement-actor-web-transport-broadcast-channel-adapter.md
+++ b/.fas/tasks/implement-actor-web-transport-broadcast-channel-adapter.md
@@ -6,7 +6,7 @@ Created with `fas create-task` on 2026-06-16.
 
 ## Problem
 
-Spike direct-1781363862864. Same-origin cross-tab/worker transport over BroadcastChannel, zero server. Implement MessageTransport on the shared transport core; address = channel/peer id (opaque, fits contract). Smallest real Axis-1 transport; proves the extracted core. Today two independent tabs cannot share actors without a websocket server.
+Location-transparency audit L4. Re-sequenced behind the foundation (unified directory, node identity, membership). BroadcastChannel is an N-way bus, but TransportCore is point-to-point and destination-validates-then-disconnects on mismatch (transport-core.ts:481-501), and defineTransport has no peer discovery. Implement as a bus-aware adapter on TransportCore: one shared channel, route inbound by frame.source, destination-filter-instead-of-disconnect, peer discovery via the membership/RuntimePeerDiscoveryProvider seam (not per-transport ad-hoc). Delivers N-tab same-origin actor sharing, not a 2-tab toy. Same-origin cross-tab/worker, zero server.
 
 ## Acceptance criteria
 

--- a/.fas/tasks/make-actor-addresses-opaque-and-mint-them-through-one-canoni.md
+++ b/.fas/tasks/make-actor-addresses-opaque-and-mint-them-through-one-canoni.md
@@ -29,11 +29,72 @@ Location-transparency audit L0. The actor address actor://node/type/id leaks the
 
 ## Affected files
 
-- Scope unknown.
+- packages/actor-core-runtime/src/utils/factories.ts
+- packages/actor-core-runtime/src/actor-system.ts
+- packages/actor-core-runtime/src/actor-system-impl.ts
+- packages/actor-core-runtime/src/topology.ts
+- packages/actor-core-runtime/src/actor-web-source.ts
+- packages/actor-core-runtime/src/distributed-actor-directory.ts
+- packages/actor-core-runtime/src/actor-system-guardian.ts
+- packages/actor-core-runtime/src/unit/actor-address.test.ts
+- packages/actor-core-runtime/src/unit/actor-source.test.ts
+- packages/actor-core-runtime/src/unit/actor-tools.test.ts
+- packages/actor-core-runtime/src/unit/actor-web-source.test.ts
+- packages/actor-core-runtime/src/unit/component-runtime-ownership.test.ts
+- packages/actor-core-runtime/src/unit/cross-node-subscription-delivery.test.ts
+- packages/actor-core-runtime/src/unit/cross-node-subscription-integration.test.ts
+- packages/actor-core-runtime/src/unit/serve-actor-web-node.test.ts
+- packages/actor-core-runtime/src/unit/start-actor-web-node.test.ts
+- packages/actor-core-runtime/src/unit/supervisor-trees.test.ts
+- packages/actor-core-runtime/src/unit/system-event-actor-processing.test.ts
+- packages/actor-core-runtime/src/unit/topology.test.ts
+- packages/actor-core-runtime/src/unit/distributed-actor-directory.test.ts
+- packages/actor-core-runtime/src/integration/event-emission-debug.test.ts
+- examples/ignite-headless-host/logistics-contract.ts
+- examples/ignite-headless-host/headless-host.test.ts
+- examples/ignite-headless-host/logistics-runtime-status.test.ts
+- examples/fas-agent-loop/fas-agent-loop.test.ts
+- packages/actor-core-runtime/src/capability-security.ts
+- packages/actor-core-runtime/src/create-actor-ref.ts
+- packages/actor-core-runtime/src/runtime-gateway.ts
+- packages/actor-core-runtime/src/utils/null-actor.ts
+- packages/actor-core-runtime/src/unit/auto-publishing-actual.test.ts
+- packages/actor-core-runtime/src/unit/message-plan.test.ts
+- packages/actor-core-runtime/src/unit/message-plan.unit.test.ts
+- packages/actor-core-runtime/src/unit/plan-interpreter.test.ts
+- packages/actor-core-runtime/src/unit/runtime-gateway.test.ts
+- packages/actor-core-runtime/src/unit/runtime-projection.test.ts
+- packages/actor-core-runtime/src/integration/actor-system-guardian.test.ts
+- packages/actor-core-runtime/src/integration/guardian-integration.test.ts
+- examples/ignite-headless-host/logistics-runtime-status-panel.tsx
 
 ## Scope Amendments
 
-- None.
+- Type: necessary-consumer-update
+- Added at: 2026-06-19
+- Trigger: breaking ActorAddress.type->kind + dropping /actor/ from actor paths
+- Reason: Architect+staff+root verified the full opaque-address surface at HEAD 283a834. Includes a 4th hidden parser (parseAddressKey) and the topology ActorWebActorAddress narrowing. Maintainer approved fixing the 4 first-party examples files in-PR (Option 1) because they are compiled by root tsconfig and run by pnpm test:examples; verify.sh --full requires them green.
+- Added paths: packages/actor-core-runtime/src/utils/factories.ts, packages/actor-core-runtime/src/actor-system.ts, packages/actor-core-runtime/src/actor-system-impl.ts, packages/actor-core-runtime/src/topology.ts, packages/actor-core-runtime/src/actor-web-source.ts, packages/actor-core-runtime/src/distributed-actor-directory.ts, packages/actor-core-runtime/src/actor-system-guardian.ts, packages/actor-core-runtime/src/unit/actor-address.test.ts, packages/actor-core-runtime/src/unit/actor-source.test.ts, packages/actor-core-runtime/src/unit/actor-tools.test.ts, packages/actor-core-runtime/src/unit/actor-web-source.test.ts, packages/actor-core-runtime/src/unit/component-runtime-ownership.test.ts, packages/actor-core-runtime/src/unit/cross-node-subscription-delivery.test.ts, packages/actor-core-runtime/src/unit/cross-node-subscription-integration.test.ts, packages/actor-core-runtime/src/unit/serve-actor-web-node.test.ts, packages/actor-core-runtime/src/unit/start-actor-web-node.test.ts, packages/actor-core-runtime/src/unit/supervisor-trees.test.ts, packages/actor-core-runtime/src/unit/system-event-actor-processing.test.ts, packages/actor-core-runtime/src/unit/topology.test.ts, packages/actor-core-runtime/src/unit/distributed-actor-directory.test.ts, packages/actor-core-runtime/src/integration/event-emission-debug.test.ts, examples/ignite-headless-host/logistics-contract.ts, examples/ignite-headless-host/headless-host.test.ts, examples/ignite-headless-host/logistics-runtime-status.test.ts, examples/fas-agent-loop/fas-agent-loop.test.ts
+- Evidence source: 6-agent architect+staff briefs (CONFUSION-A/B/C) + root verification of root package.json test + tsconfig include
+- Evidence: 6-agent architect+staff briefs (CONFUSION-A/B/C) + root verification of root package.json test + tsconfig include
+
+- Type: scope-refresh-promotion
+- Added at: 2026-06-20
+- Trigger: dirty-low-confidence-scope
+- Reason: Promoted dirty low-confidence or dependency-reachable task-packet path(s) into affected scope.
+- Added paths: packages/actor-core-runtime/src/actor-web-source.ts
+- Evidence source: task-packet dirty scope promotion
+- Evidence: task-packet dirty scope promotion | .fas/state/task-packet.json | Promoted dirty path(s): packages/actor-core-runtime/src/actor-web-source.ts
+- Accuracy signal: Path was dirty in git status and present in task-packet low-confidence/dependency-reachable scope.
+
+## Scope Amendments (implementation-discovered consumers)
+
+- Type: necessary-consumer-update
+- Added at: 2026-06-19
+- Trigger: the atomic ActorAddress.type->kind rename makes additional first-party consumers non-compiling that the original brief scope did not enumerate; the package typecheck (tsc over src/**/*) and root typecheck (examples) both flag them.
+- Reason: These are the mechanical fan-out of the LOCKED field rename, not a design change. They mirror the guardian precedent (site 11): non-uniform sentinel/mock addresses ('mock'/'unified'/'null'/'system'/'test'/'worker') coerce their old type to kind:'actor'; runtime-gateway address equality compares kind instead of type. No widening of the kind union. Fixing them is required for fas validate-task (lint/typecheck) and the root gate to go green.
+- Added paths: packages/actor-core-runtime/src/capability-security.ts, packages/actor-core-runtime/src/create-actor-ref.ts, packages/actor-core-runtime/src/runtime-gateway.ts, packages/actor-core-runtime/src/utils/null-actor.ts, packages/actor-core-runtime/src/unit/auto-publishing-actual.test.ts, packages/actor-core-runtime/src/unit/message-plan.test.ts, packages/actor-core-runtime/src/unit/message-plan.unit.test.ts, packages/actor-core-runtime/src/unit/plan-interpreter.test.ts, packages/actor-core-runtime/src/unit/runtime-gateway.test.ts, packages/actor-core-runtime/src/unit/runtime-projection.test.ts, packages/actor-core-runtime/src/integration/actor-system-guardian.test.ts, packages/actor-core-runtime/src/integration/guardian-integration.test.ts, examples/ignite-headless-host/logistics-runtime-status-panel.tsx
+- Evidence: fas validate-task changeset receipt unexpectedFiles (5 source) + planAlignmentSummary.testCoverageFiles (8 test); full package vitest run 558 passed; root pnpm typecheck + pnpm test:examples (51 passed) green.
 
 ## Implementation plan
 

--- a/.fas/tasks/make-actor-addresses-opaque-and-mint-them-through-one-canoni.md
+++ b/.fas/tasks/make-actor-addresses-opaque-and-mint-them-through-one-canoni.md
@@ -67,6 +67,7 @@ Location-transparency audit L0. The actor address actor://node/type/id leaks the
 - packages/actor-core-runtime/src/integration/actor-system-guardian.test.ts
 - packages/actor-core-runtime/src/integration/guardian-integration.test.ts
 - examples/ignite-headless-host/logistics-runtime-status-panel.tsx
+- .changeset/opaque-actor-addresses.md
 
 ## Scope Amendments
 
@@ -86,6 +87,12 @@ Location-transparency audit L0. The actor address actor://node/type/id leaks the
 - Evidence source: task-packet dirty scope promotion
 - Evidence: task-packet dirty scope promotion | .fas/state/task-packet.json | Promoted dirty path(s): packages/actor-core-runtime/src/actor-web-source.ts
 - Accuracy signal: Path was dirty in git status and present in task-packet low-confidence/dependency-reachable scope.
+
+- Type: release-changeset
+- Added at: 2026-06-20
+- Trigger: maintainer-approved minor changeset for the breaking address change
+- Reason: Published @actor-web/runtime uses Changesets; the breaking ActorAddress.type->kind + 2-seg path change needs a minor changeset (0.2.0 release plan). Maintainer chose minor + ship in this PR.
+- Added paths: .changeset/opaque-actor-addresses.md
 
 ## Scope Amendments (implementation-discovered consumers)
 

--- a/.fas/tasks/make-actor-addresses-opaque-and-mint-them-through-one-canoni.md
+++ b/.fas/tasks/make-actor-addresses-opaque-and-mint-them-through-one-canoni.md
@@ -1,12 +1,12 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Make actor addresses opaque and mint them through one canonical factory
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L0. The actor address actor://node/type/id leaks the physical node, the type segment is a hardcoded constant, and minting is duplicated (system.spawn actor-system-impl.ts:982-990 vs topology.ts:559-573); node=local normalization (utils/factories.ts:68; actor-system.ts:759-767) diverges from concrete node strings, a latent transparency leak. Centralize minting in one factory used by spawn and topology; treat the path as an opaque key end-to-end; one canonical local-node normalization. Foundation for the unified directory.
 
 ## Acceptance criteria
 

--- a/.fas/tasks/post-mesh-scoping-membership-graduation-tier-cross-node-supe.md
+++ b/.fas/tasks/post-mesh-scoping-membership-graduation-tier-cross-node-supe.md
@@ -1,17 +1,16 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Post-mesh scoping: membership graduation tier, cross-node supervision boundary, claim gating
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L6. After membership lands: (1) decide whether @actor-web/labs-mesh graduates from labs to a supported tier and gate the UNCONDITIONAL location-transparency claim on it; (2) document the node-local supervision boundary and scope cross-node monitor/link/nodedown semantics (today supervision is node-local; peer-down purges directory entries with no failover). Decision and scoping, not implementation.
 
 ## Acceptance criteria
 
-- The new functionality works as described.
-- Existing behavior is not broken.
+- The change is verified and does not introduce regressions.
 - TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
 - TDD: every production code change in the change set is covered by an added or updated test.
 - DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.

--- a/.fas/tasks/transport-large-payload-framing-chunking-contract-or-explici.md
+++ b/.fas/tasks/transport-large-payload-framing-chunking-contract-or-explici.md
@@ -1,17 +1,16 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Transport: large-payload framing/chunking contract or explicit max-payload with blob-externalization
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L5 (agent-payload gap, UNOWNED). The transport bounds outbound queues and REJECTS on overflow (external-transport-design.md:521-525) with no chunking. LLM agents ship large prompts/results/context blobs. Define a framing/chunking and reassembly contract at the transport seam, OR an explicit max-payload contract plus guidance to externalize blobs. Prerequisite for streaming large agent output.
 
 ## Acceptance criteria
 
-- The new functionality works as described.
-- Existing behavior is not broken.
+- The change is verified and does not introduce regressions.
 - TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
 - TDD: every production code change in the change set is covered by an added or updated test.
 - DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.

--- a/.fas/tasks/unify-actor-location-truth-single-directory-backed-resolutio.md
+++ b/.fas/tasks/unify-actor-location-truth-single-directory-backed-resolutio.md
@@ -1,17 +1,16 @@
-# Implement @actor-web/labs-mesh (gossip membership + multi-hop routing + directory propagation)
+# Unify actor location truth: single directory-backed resolution for send and emit/subscribe
 
 ## Source
 
-Created with `fas create-task` on 2026-06-16.
+Created with `fas create-task` on 2026-06-19.
 
 ## Problem
 
-Spike direct-1781363862864. The real Mesh: arbitrary node graph where an actor on A reaches an actor on Z with no direct edge, dynamic join/leave via gossip, cluster-wide directory. Built as a labs package on the injectable directory (P3), the next-hop routing hook (P4), formalized node identity (P5), and the shared transport core (P2) + existing RuntimePeerDiscoveryProvider. broadcastRegister/Unregister/Lookup in distributed-actor-directory.ts are no-op stubs today and propagation is point-to-point only.
+Location-transparency audit L0 ROOT FIX (highest leverage). Two parallel registries are both location truth: DistributedActorDirectory (path to node) and AutoPublishingRegistry (publisherId to direct ActorRef). emitEventToSubscribers (actor-system-impl.ts:2684) reads subscriber refs from auto-publishing, then enqueueMessage re-resolves each subscriber address via directory.lookup (1688) and dead-letters on miss (1700-1701), the verified root of the fas-studio bug. Make the directory the single source of location truth: auto-publishing stores addresses or directory handles not refs; emit delivers through the same address chokepoint as send; reconcile registration so an actor cannot be subscriber or publisher without a directory entry; stop TTL-expiring own-node entries. Regression test: two co-located topology actors with a declarative subscription plus emit asserting zero dead-letters and zero console.error against a real directory-backed runtime.
 
 ## Acceptance criteria
 
-- The new functionality works as described.
-- Existing behavior is not broken.
+- The change is verified and does not introduce regressions.
 - TDD: a failing test that captures the new or changed behavior is written before the implementation and lands in the same change.
 - TDD: every production code change in the change set is covered by an added or updated test.
 - DDD: respect domain boundaries — keep the functional core deterministic and side-effect-free (no reads, writes, network, or clock), confine coordination to the imperative shell, and have adapters return facts instead of throwing.

--- a/docs/spikes/location-transparency-audit.md
+++ b/docs/spikes/location-transparency-audit.md
@@ -1,0 +1,49 @@
+# Location-Transparency Architecture Audit — actor-web
+
+Date: 2026-06-19 · Mode: read-only (3 bounded reviewers + root synthesis) · Branch: fas/transport-core
+
+## Question
+Does actor-web back its stated claim that actors — and LLM agents — run identically local or distributed (Erlang/Elixir/OTP-style location transparency)?
+
+## Headline verdict
+- **API level:** YES. Behaviors are transport-agnostic; the `MessageTransport` seam and the `RuntimePeerDiscoveryProvider` port are well-designed; transports do NOT each reinvent discovery (discovery lives above the transport). The bones are right.
+- **Local:** MOSTLY, with a STRUCTURAL crack. Location truth is split across two independently-keyed registries (`DistributedActorDirectory` path→node; `AutoPublishingRegistry` publisherId→direct refs) plus side-channel delivery paths. The emit fan-out bridges them unsafely → the fas-studio dead-letter. The directory is NOT the single source of location truth.
+- **Distributed:** honestly-caveated POINT-TO-POINT, not a cluster. Real cross-node send/ask/subscribe works between directly-connected, statically-configured nodes (cross-node subscription delivery is DONE + reconnect-aware). Missing: autonomous membership/discovery (cross-node directory fill is TODO no-op stubs; only static/in-memory discovery providers), multi-hop routing, durable/collision-safe node identity (incarnation=Date.now(), nodeId defaults to nodeAddress, node='local' default), cross-node supervision.
+- **Claims honesty:** docs are unusually candid (README:67, runtime README:77-84, API.md:1108-1111, the external-transport spike doc). Dominant risk is DRIFT: hero one-liners assert "distributed/location-transparent" flatly; README:67 is now partly stale-in-your-favor.
+
+## Claimed → Implemented → Missing
+| Capability | State | Evidence |
+|---|---|---|
+| Logical/opaque address | leaky — actor://node/type/id leaks node; `type` constant; node='local' vs concrete diverge | actor-system.ts:98-103; actor-system-impl.ts:982-990; utils/factories.ts:68 |
+| Single directory = location truth | NO — two registries + side channels | distributed-actor-directory.ts:112,412; auto-publishing.ts:50,268; actor-system-impl.ts:2688→2714→1688-1701 |
+| Local send/emit/subscribe | works except emit-fan-out dead-letter (fas-studio) | verified: emitEventToSubscribers:2684 → enqueueMessage:1688 → error+deadletter:1700-1701 |
+| Cross-node send/ask/subscribe (direct edge) | DONE, reconnect-replay aware | actor-system-impl.ts:2898-2931,:3237 |
+| Membership/discovery (EPMD/net_kernel) | ABSENT — seam exists, only static providers; directory broadcast = TODO stubs | runtime-peer-discovery.ts:203,215; distributed-actor-directory.ts:447-479 |
+| Stable/durable node identity | NO — Date.now() incarnation, node='local' collision hazard | node-websocket-…:630-631; define-transport.ts:267-268; factories.ts:68 |
+| Multi-hop routing | NO — point-to-point; disconnect-on-mismatch; router hook queued | transport-core.ts:481-501; deliverMessageRemote:4052-4064 |
+| Cross-node supervision / nodedown | NO — node-local only | applySupervisionStrategy:4073; peer-down purge:3240-3277 |
+| Delivery guarantee | at-most-once app sends (documented) | runtime README:77-84 |
+
+## Findings (deduped, severity-ordered)
+1. HIGH — **Local location truth is not unified.** Two registries + non-uniform delivery paths; emit re-resolves subscriber addresses through the directory and dead-letters on miss. Root of the fas-studio bug; the deepest transparency crack; bites before distribution. Fix: directory = single source; auto-publishing stores addresses (not refs); emit delivers through the same chokepoint as send; reconcile registration; do not TTL-expire own-node entries.
+2. HIGH — **Node identity is non-durable & collision-prone.** Date.now() incarnation, nodeId=nodeAddress, node='local' default → directory corruption the moment two nodes sync. (Owned: task-1781628465954.)
+3. HIGH (agent north-star) — **Agent-payload transparency is unowned.** Plain-actor transport does NOT cover: (a) streaming tool/agent output across nodes; (b) large-payload framing/chunking (transport queues REJECT on overflow); (c) at-least-once/idempotency for non-idempotent tool side-effects (at-most-once silently drops a write-file/open-PR/send-email). No backlog tasks exist.
+4. MEDIUM — **No membership/cluster layer,** but owned-by-design: seams (injectable directory, next-hop hook, identity) are discrete queued tasks; implementation is @actor-web/labs-mesh (deferred), whose brief is a content-free stub.
+5. MEDIUM — **TransportCore is single-hop by design** (disconnect-on-mismatch); multi-hop must be higher-layer re-framing via the next-hop router hook, not transport forwarding. Document the contract.
+6. LOW/MEDIUM — **Docs drift:** scope the headline claim at first mention; reconcile multi-machine "done" (TASKS.md:535) vs "remaining" (external-transport-design.md:204); refresh README:67.
+7. LOW — **Declarative emit/subscribe path under-exercised** through a directory-backed runtime; only caught by an external consumer (fas-studio), not a framework example.
+
+## LLM-agents-as-actors fit
+Substrate is CLEAN: an agent is a behavior calling an `llm` tool, inheriting address/directory/supervision/transport; examples/fas-agent-loop already runs two agent nodes over real WebSocket transport. Gaps: the @actor-web/agent package is unbuilt (task-1781123183558); plus the 3 agent-payload gaps in Finding 3 (streaming, framing, at-least-once for side-effecting tools).
+
+## Recommended layered sequence (foundation first)
+- L0 (local foundation): unify location truth (incl. TTL fix) [root]; opaque addresses + single minting factory; fix fas-studio as the regression test; add a directory-backed declarative-subscriptions example.
+- L1: formalize node identity (durable incarnation, collision protection, reject node='local' for remote).
+- L2: injectable directory; next-hop routing hook (+ document single-hop transport contract).
+- L3: author labs-mesh design doc; implement labs-mesh (gossip membership + cluster-wide directory + multi-hop).
+- L4: transports as thin media — T1 broadcast (bus-aware destination-filter, discovery via membership), T2 webrtc (drives defineTransport smart-pipe growth), Mesh Pong parity demo.
+- L5 (agent track, parallel after L0): @actor-web/agent package; streaming; large-payload framing; at-least-once for side-effecting tools.
+- L6 (docs/decisions): docs honesty pass; post-mesh scoping (membership graduation tier, cross-node supervision boundary, claim-gating).
+
+## Confidence / open items
+Verified firsthand: the two-registries + emit re-lookup dead-letter (linchpin), and the TransportCore point-to-point/disconnect behavior (from P2). Reviewer-cited (high-confidence, specific line refs, not re-run by root): "no autonomous membership," "cross-node subscription is done." NOT pinned: the exact fas-studio 0.1.0 trigger — the brief conflates the subscriber re-lookup dead-letter with a separate `[AUTO_PUBLISHING] no metadata` publisher-tracking miss; pin with a live repro during the fix.

--- a/examples/fas-agent-loop/fas-agent-loop.test.ts
+++ b/examples/fas-agent-loop/fas-agent-loop.test.ts
@@ -38,13 +38,13 @@ describe('fas-agent-loop example', () => {
 
   it('declares coordinator and worker topology with least-privilege agent tools', () => {
     expect(fasAgentLoop.actors.taskBoard.address.path).toBe(
-      'actor://fas-coordinator-runtime/actor/fas-task-board'
+      'actor://fas-coordinator-runtime/fas-task-board'
     );
     expect(fasAgentLoop.actors.taskBoard.gateway).toEqual({
       scope: { kind: 'taskBoard' },
     });
     expect(fasAgentLoop.actors.taskRun.resolveAddress(TEST_TASK).path).toBe(
-      'actor://fas-coordinator-runtime/actor/fas-task-task-1001'
+      'actor://fas-coordinator-runtime/fas-task-task-1001'
     );
     expect(fasAgentLoop.actors.plannerAgent.tools).toEqual([]);
     expect(fasAgentLoop.actors.implementerAgent.tools).toEqual(['codex.generate_patch']);
@@ -113,7 +113,7 @@ describe('fas-agent-loop example', () => {
         'Expected task board source to connect through the coordinator gateway'
       );
 
-      expect(source.address.path).toBe('actor://fas-coordinator-runtime/actor/fas-task-board');
+      expect(source.address.path).toBe('actor://fas-coordinator-runtime/fas-task-board');
       await source.send({ type: 'SUBMIT_TASK', ...TEST_TASK });
       await waitFor(
         () => source.snapshot().context.activeTaskId === TEST_TASK.taskId,
@@ -205,8 +205,8 @@ describe('fas-agent-loop example', () => {
     const first = await runtime.getTask('task-1001');
     const second = await runtime.getTask('task-2002');
 
-    expect(first?.address.path).toBe('actor://fas-coordinator-runtime/actor/fas-task-task-1001');
-    expect(second?.address.path).toBe('actor://fas-coordinator-runtime/actor/fas-task-task-2002');
+    expect(first?.address.path).toBe('actor://fas-coordinator-runtime/fas-task-task-1001');
+    expect(second?.address.path).toBe('actor://fas-coordinator-runtime/fas-task-task-2002');
     expect(first?.getSnapshot().context.title).toBe('Implement deterministic FAS loop');
     expect(second?.getSnapshot().context.title).toBe('Verify isolated task actor');
     expect(runtime.taskBoard.getSnapshot().context.tasks).toHaveLength(2);

--- a/examples/ignite-headless-host/headless-host.test.ts
+++ b/examples/ignite-headless-host/headless-host.test.ts
@@ -75,7 +75,7 @@ describe('ignite-headless-host logistics example', () => {
 
   it('declares topology-owned actors and supervision metadata', () => {
     expect(logistics.actors.shipment.address.path).toBe(
-      'actor://logistics-server-runtime/actor/logistics-shipment'
+      'actor://logistics-server-runtime/logistics-shipment'
     );
     expect(logistics.actors.shipment.supervision).toMatchObject({
       strategy: 'restart',
@@ -96,13 +96,13 @@ describe('ignite-headless-host logistics example', () => {
       ],
     });
     expect(logistics.actors.providerHq.address.path).toBe(
-      'actor://logistics-server-runtime/actor/logistics-provider-hq'
+      'actor://logistics-server-runtime/logistics-provider-hq'
     );
     expect(logistics.actors.dispatcher.address.path).toBe(
-      'actor://logistics-server-runtime/actor/logistics-dispatcher'
+      'actor://logistics-server-runtime/logistics-dispatcher'
     );
     expect(logistics.actors.driverDirectory.address.path).toBe(
-      'actor://logistics-server-runtime/actor/logistics-driver-directory'
+      'actor://logistics-server-runtime/logistics-driver-directory'
     );
   });
 
@@ -826,10 +826,9 @@ describe('ignite-headless-host logistics example', () => {
         providerRuntime: 'logistics-provider-runtime',
       },
       actors: {
-        shipment: 'actor://logistics-server-runtime/actor/logistics-shipment',
-        routing: 'actor://logistics-worker-runtime/actor/logistics-routing',
-        providerRuntime:
-          'actor://logistics-provider-runtime/actor/logistics-provider-runtime-manager',
+        shipment: 'actor://logistics-server-runtime/logistics-shipment',
+        routing: 'actor://logistics-worker-runtime/logistics-routing',
+        providerRuntime: 'actor://logistics-provider-runtime/logistics-provider-runtime-manager',
       },
     });
 
@@ -987,7 +986,7 @@ describe('logistics runtime planning functions', () => {
       logistics.actors.shipmentLifecycle.resolveAddress({ shipmentId: 'shipment/a b' })
     ).toMatchObject({
       id: 'logistics-shipment-shipment-a-b',
-      path: 'actor://logistics-server-runtime/actor/logistics-shipment-shipment-a-b',
+      path: 'actor://logistics-server-runtime/logistics-shipment-shipment-a-b',
     });
     expect(shipmentLifecycleActorId({ shipmentId: 'shipment/a b' })).toBe(
       'logistics-shipment-shipment-a-b'

--- a/examples/ignite-headless-host/logistics-contract.ts
+++ b/examples/ignite-headless-host/logistics-contract.ts
@@ -356,23 +356,23 @@ export type ProviderSignalSourceLabel = 'manual UI' | 'simulator process' | 'pro
 
 export const REMOTE_ADDRESS = {
   id: REMOTE_ACTOR_ID,
-  type: 'actor',
+  kind: 'actor',
   node: REMOTE_NODE,
-  path: `actor://${REMOTE_NODE}/actor/${REMOTE_ACTOR_ID}`,
+  path: `actor://${REMOTE_NODE}/${REMOTE_ACTOR_ID}`,
 } as const;
 
 export const PROVIDER_HQ_ADDRESS = {
   id: PROVIDER_HQ_ACTOR_ID,
-  type: 'actor',
+  kind: 'actor',
   node: REMOTE_NODE,
-  path: `actor://${REMOTE_NODE}/actor/${PROVIDER_HQ_ACTOR_ID}`,
+  path: `actor://${REMOTE_NODE}/${PROVIDER_HQ_ACTOR_ID}`,
 } as const;
 
 export const PROVIDER_RUNTIME_ADDRESS = {
   id: PROVIDER_RUNTIME_ACTOR_ID,
-  type: 'actor',
+  kind: 'actor',
   node: PROVIDER_NODE,
-  path: `actor://${PROVIDER_NODE}/actor/${PROVIDER_RUNTIME_ACTOR_ID}`,
+  path: `actor://${PROVIDER_NODE}/${PROVIDER_RUNTIME_ACTOR_ID}`,
 } as const;
 
 export type ProviderRuntimeCommand =
@@ -389,37 +389,37 @@ export type ProviderRuntimeCommand =
 
 export const LOGISTICS_SUPERVISOR_ADDRESS = {
   id: LOGISTICS_SUPERVISOR_ACTOR_ID,
-  type: 'actor',
+  kind: 'actor',
   node: REMOTE_NODE,
-  path: `actor://${REMOTE_NODE}/actor/${LOGISTICS_SUPERVISOR_ACTOR_ID}`,
+  path: `actor://${REMOTE_NODE}/${LOGISTICS_SUPERVISOR_ACTOR_ID}`,
 } as const;
 
 export const DISPATCHER_ADDRESS = {
   id: DISPATCHER_ACTOR_ID,
-  type: 'actor',
+  kind: 'actor',
   node: REMOTE_NODE,
-  path: `actor://${REMOTE_NODE}/actor/${DISPATCHER_ACTOR_ID}`,
+  path: `actor://${REMOTE_NODE}/${DISPATCHER_ACTOR_ID}`,
 } as const;
 
 export const DRIVER_DIRECTORY_ADDRESS = {
   id: DRIVER_DIRECTORY_ACTOR_ID,
-  type: 'actor',
+  kind: 'actor',
   node: REMOTE_NODE,
-  path: `actor://${REMOTE_NODE}/actor/${DRIVER_DIRECTORY_ACTOR_ID}`,
+  path: `actor://${REMOTE_NODE}/${DRIVER_DIRECTORY_ACTOR_ID}`,
 } as const;
 
 export const WORKER_ADDRESS = {
   id: WORKER_ACTOR_ID,
-  type: 'actor',
+  kind: 'actor',
   node: WORKER_NODE,
-  path: `actor://${WORKER_NODE}/actor/${WORKER_ACTOR_ID}`,
+  path: `actor://${WORKER_NODE}/${WORKER_ACTOR_ID}`,
 } as const;
 
 export const SERVICE_WORKER_ADDRESS = {
   id: SERVICE_WORKER_ACTOR_ID,
-  type: 'actor',
+  kind: 'actor',
   node: SERVICE_WORKER_NODE,
-  path: `actor://${SERVICE_WORKER_NODE}/actor/${SERVICE_WORKER_ACTOR_ID}`,
+  path: `actor://${SERVICE_WORKER_NODE}/${SERVICE_WORKER_ACTOR_ID}`,
 } as const;
 
 export function createInitialShipmentContext(): ShipmentContext {

--- a/examples/ignite-headless-host/logistics-runtime-status-panel.tsx
+++ b/examples/ignite-headless-host/logistics-runtime-status-panel.tsx
@@ -43,6 +43,7 @@ function createRuntimeStatusSource(): { source: RuntimeStatusSource; stop(): voi
     address: {
       id: 'logistics-runtime-status-panel',
       kind: 'actor',
+      node: 'logistics-browser-host',
       path: 'actor://logistics-browser-host/logistics-runtime-status-panel',
     },
     snapshot: () => {

--- a/examples/ignite-headless-host/logistics-runtime-status-panel.tsx
+++ b/examples/ignite-headless-host/logistics-runtime-status-panel.tsx
@@ -42,8 +42,8 @@ function createRuntimeStatusSource(): { source: RuntimeStatusSource; stop(): voi
   const source: RuntimeStatusSource = {
     address: {
       id: 'logistics-runtime-status-panel',
-      type: 'actor',
-      path: 'actor://logistics-browser-host/actor/logistics-runtime-status-panel',
+      kind: 'actor',
+      path: 'actor://logistics-browser-host/logistics-runtime-status-panel',
     },
     snapshot: () => {
       const phase = context.pollingError ? 'degraded' : 'ready';

--- a/examples/ignite-headless-host/logistics-runtime-status.test.ts
+++ b/examples/ignite-headless-host/logistics-runtime-status.test.ts
@@ -101,15 +101,14 @@ function createStatusResponse(
       serviceWorkerRuntime: 'logistics-service-worker-runtime',
     },
     actors: {
-      shipment: 'actor://logistics-server-runtime/actor/logistics-shipment',
-      routing: 'actor://logistics-worker-runtime/actor/logistics-routing',
-      providerHq: 'actor://logistics-server-runtime/actor/logistics-provider-hq',
-      providerRuntime:
-        'actor://logistics-provider-runtime/actor/logistics-provider-runtime-manager',
-      logisticsSupervisor: 'actor://logistics-server-runtime/actor/logistics-supervisor',
-      dispatcher: 'actor://logistics-server-runtime/actor/logistics-dispatcher',
-      driverDirectory: 'actor://logistics-server-runtime/actor/logistics-driver-directory',
-      serviceWorkerProof: 'actor://logistics-service-worker-runtime/actor/service-worker-proof',
+      shipment: 'actor://logistics-server-runtime/logistics-shipment',
+      routing: 'actor://logistics-worker-runtime/logistics-routing',
+      providerHq: 'actor://logistics-server-runtime/logistics-provider-hq',
+      providerRuntime: 'actor://logistics-provider-runtime/logistics-provider-runtime-manager',
+      logisticsSupervisor: 'actor://logistics-server-runtime/logistics-supervisor',
+      dispatcher: 'actor://logistics-server-runtime/logistics-dispatcher',
+      driverDirectory: 'actor://logistics-server-runtime/logistics-driver-directory',
+      serviceWorkerProof: 'actor://logistics-service-worker-runtime/service-worker-proof',
     },
   };
 }

--- a/examples/ignite-headless-host/logistics-runtime-status.test.ts
+++ b/examples/ignite-headless-host/logistics-runtime-status.test.ts
@@ -108,7 +108,7 @@ function createStatusResponse(
       logisticsSupervisor: 'actor://logistics-server-runtime/logistics-supervisor',
       dispatcher: 'actor://logistics-server-runtime/logistics-dispatcher',
       driverDirectory: 'actor://logistics-server-runtime/logistics-driver-directory',
-      serviceWorkerProof: 'actor://logistics-service-worker-runtime/service-worker-proof',
+      serviceWorkerProof: 'actor://logistics-service-worker-runtime/logistics-service-worker-proof',
     },
   };
 }

--- a/packages/actor-core-runtime/src/actor-system-guardian.ts
+++ b/packages/actor-core-runtime/src/actor-system-guardian.ts
@@ -446,9 +446,13 @@ function hasCorrelationId(message: unknown): message is { _correlationId: string
 /**
  * Guardian Actor Address - Well-known system address
  */
+// Guardian keeps a non-uniform well-known address: path is /system/guardian
+// (not the actor:// scheme) and kind is coerced to 'actor' since 'system' is
+// not a valid address kind. Reconciling the guardian + callback address shapes
+// is deferred to the unify-directory task. Do NOT add 'system' to the kind union.
 export const GUARDIAN_ADDRESS: ActorAddress = {
   id: 'guardian',
-  type: 'system',
+  kind: 'actor',
   node: 'local',
   path: '/system/guardian',
 };

--- a/packages/actor-core-runtime/src/actor-system-impl.ts
+++ b/packages/actor-core-runtime/src/actor-system-impl.ts
@@ -108,7 +108,7 @@ import {
 import { StatelessActor } from './stateless-actor.js';
 import type { ContextOf, MessageOf } from './type-helpers.js';
 import type { ActorSnapshot, JsonValue, Message } from './types.js';
-import { generateCorrelationId } from './utils/factories.js';
+import { createActorAddress, generateCorrelationId } from './utils/factories.js';
 
 // ✅ Define specific message types for type safety
 interface SpawnChildMessage extends ActorMessage {
@@ -979,15 +979,16 @@ export class ActorSystemImpl implements ActorSystem {
     }
 
     const id = options?.id || this.generateActorId();
-    const type = 'actor'; // SpawnOptions doesn't have type field
-    const path = `actor://${this.config.nodeAddress}/${type}/${id}`;
 
     // Check max actors limit
     if (this.config.maxActors && this.getLocalActorCount() >= this.config.maxActors) {
       throw new Error(`Maximum actor limit reached: ${this.config.maxActors}`);
     }
 
-    const address: ActorAddress = { id, type, path };
+    const address = createActorAddress(id, this.config.nodeAddress);
+    // Opaque path key reused for the per-actor registries below (behavior
+    // unchanged: this is the same string the old inline mint produced).
+    const path = address.path;
 
     // Store the per-actor supervision policy so the failure path can honor
     // strategy/maxRestarts/withinMs. Validate the strategy at runtime for
@@ -1114,7 +1115,7 @@ export class ActorSystemImpl implements ActorSystem {
 
     log.debug('Actor spawned', {
       id,
-      type,
+      kind: address.kind,
       path,
       totalActors: this.getLocalActorCount(),
     });

--- a/packages/actor-core-runtime/src/actor-system.ts
+++ b/packages/actor-core-runtime/src/actor-system.ts
@@ -97,7 +97,7 @@ export type MessagePlan<_TDomainEvent = unknown> = unknown; // Will be properly 
  */
 export interface ActorAddress {
   readonly id: string;
-  readonly type: string;
+  readonly kind: 'actor' | 'callback';
   readonly node?: string;
   readonly path: string;
 }
@@ -757,13 +757,15 @@ export interface ActorSupervisor {
  * Parse an actor path into an address
  */
 export function parseActorPath(path: string): ActorAddress {
-  const match = path.match(/^actor:\/\/([^/]+)\/([^/]+)\/(.+)$/);
-  if (!match) {
-    throw new Error(`Invalid actor path: ${path}`);
+  const callback = path.match(/^actor:\/\/([^/]+)\/callback\/(.+)$/);
+  if (callback) {
+    const [, node, id] = callback;
+    return createActorAddress(id, node === 'local' ? undefined : node, 'callback');
   }
-
-  const [, node, type, id] = match;
-  return createActorAddress(id, type, node === 'local' ? undefined : node);
+  const actor = path.match(/^actor:\/\/([^/]+)\/(.+)$/);
+  if (!actor) throw new Error(`Invalid actor path: ${path}`);
+  const [, node, id] = actor;
+  return createActorAddress(id, node === 'local' ? undefined : node, 'actor');
 }
 
 /**

--- a/packages/actor-core-runtime/src/actor-web-source.ts
+++ b/packages/actor-core-runtime/src/actor-web-source.ts
@@ -1,5 +1,6 @@
 import type { ActorEventSubscriptionOptions } from './actor-ref.js';
 import type { ActorAddress, ActorMessage } from './actor-system.js';
+import { parseActorPath } from './actor-system.js';
 import {
   type ActorCommandSource,
   type ActorReadModelSource,
@@ -169,16 +170,7 @@ function normalizeAddress(address: string | ActorWebActorAddress | ActorAddress)
     return address;
   }
 
-  const match = /^actor:\/\/([^/]+)\/actor\/(.+)$/.exec(address);
-  const id = match?.[2] ?? address.split('/').at(-1) ?? address;
-  const node = match?.[1];
-
-  return {
-    id,
-    type: 'actor',
-    ...(node ? { node } : {}),
-    path: address,
-  };
+  return parseActorPath(address);
 }
 
 function placeholderSnapshot<TContext>(address: ActorAddress): ActorSourceSnapshot<TContext> {

--- a/packages/actor-core-runtime/src/capability-security.ts
+++ b/packages/actor-core-runtime/src/capability-security.ts
@@ -7,6 +7,7 @@
 import type { ActorRef } from './actor-ref.js';
 import { Logger } from './logger.js';
 import type { BaseEventObject, JsonValue } from './types.js';
+import { createActorAddress } from './utils/factories.js';
 import type { VirtualActorSystem } from './virtual-actor-system.js';
 
 // ========================================================================================
@@ -390,7 +391,7 @@ export class InMemoryCapabilityRegistry implements CapabilityRegistry {
     // Fall back to mock actor ref for testing or when no virtual actor system is provided
     this.logger.debug('Using mock actor ref (no virtual actor system)', { actorId });
     const mockActorRef: ActorRef<BaseEventObject> = {
-      address: { id: actorId, kind: 'actor', path: `/actors/${actorId}` },
+      address: createActorAddress(actorId),
       send: async () => {},
       ask: async <TResponse = JsonValue>() => ({ success: true }) as TResponse,
       stop: async () => {},

--- a/packages/actor-core-runtime/src/capability-security.ts
+++ b/packages/actor-core-runtime/src/capability-security.ts
@@ -390,7 +390,7 @@ export class InMemoryCapabilityRegistry implements CapabilityRegistry {
     // Fall back to mock actor ref for testing or when no virtual actor system is provided
     this.logger.debug('Using mock actor ref (no virtual actor system)', { actorId });
     const mockActorRef: ActorRef<BaseEventObject> = {
-      address: { id: actorId, type: 'mock', path: `/actors/${actorId}` },
+      address: { id: actorId, kind: 'actor', path: `/actors/${actorId}` },
       send: async () => {},
       ask: async <TResponse = JsonValue>() => ({ success: true }) as TResponse,
       stop: async () => {},

--- a/packages/actor-core-runtime/src/create-actor-ref.ts
+++ b/packages/actor-core-runtime/src/create-actor-ref.ts
@@ -144,7 +144,7 @@ class XStateActorRef<TContext = unknown, TMessage extends ActorMessage = ActorMe
   get address(): ActorAddress {
     return {
       id: this._id,
-      type: 'unified',
+      kind: 'actor',
       path: `/actors/${this._id}`,
     };
   }

--- a/packages/actor-core-runtime/src/create-actor-ref.ts
+++ b/packages/actor-core-runtime/src/create-actor-ref.ts
@@ -29,7 +29,7 @@ import type {
   SpawnOptions,
   SupervisionStrategy,
 } from './types.js';
-import { generateActorId } from './utils/factories.js';
+import { createActorAddress, generateActorId } from './utils/factories.js';
 
 /**
  * Type guard for AnyStateMachine
@@ -142,11 +142,7 @@ class XStateActorRef<TContext = unknown, TMessage extends ActorMessage = ActorMe
   }
 
   get address(): ActorAddress {
-    return {
-      id: this._id,
-      kind: 'actor',
-      path: `/actors/${this._id}`,
-    };
+    return createActorAddress(this._id);
   }
 
   get status(): ActorStatus {

--- a/packages/actor-core-runtime/src/distributed-actor-directory.ts
+++ b/packages/actor-core-runtime/src/distributed-actor-directory.ts
@@ -419,7 +419,10 @@ export class DistributedActorDirectory implements ActorDirectory {
   private parseAddressKey(key: string): ActorAddress | undefined {
     try {
       return parseActorPath(key);
-    } catch {
+    } catch (error) {
+      // A canonical mint always round-trips; a parse failure signals a malformed or
+      // divergent key, so surface it instead of silently dropping it from listings.
+      log.warn('Failed to parse actor directory key', { key, error });
       return undefined;
     }
   }

--- a/packages/actor-core-runtime/src/distributed-actor-directory.ts
+++ b/packages/actor-core-runtime/src/distributed-actor-directory.ts
@@ -11,6 +11,7 @@
  */
 
 import type { ActorAddress, ActorDirectory } from './actor-system.js';
+import { parseActorPath } from './actor-system.js';
 import { Logger } from './logger.js';
 import { createActorInterval } from './pure-xstate-utilities.js';
 import type { RuntimeDirectoryEntry } from './runtime-transport-protocol.js';
@@ -259,7 +260,7 @@ export class DistributedActorDirectory implements ActorDirectory {
     for (const [key, entry] of this.registry) {
       if (entry.ttl > now) {
         const address = this.parseAddressKey(key);
-        if (address?.type === type) {
+        if (address?.kind === type) {
           addresses.push(address);
           checkedKeys.add(key);
         }
@@ -270,7 +271,7 @@ export class DistributedActorDirectory implements ActorDirectory {
     for (const [key, entry] of this.cache) {
       if (!checkedKeys.has(key) && entry.ttl > now) {
         const address = this.parseAddressKey(key);
-        if (address?.type === type) {
+        if (address?.kind === type) {
           addresses.push(address);
         }
       }
@@ -417,18 +418,8 @@ export class DistributedActorDirectory implements ActorDirectory {
    */
   private parseAddressKey(key: string): ActorAddress | undefined {
     try {
-      const match = key.match(/^actor:\/\/([^/]+)\/([^/]+)\/(.+)$/);
-      if (!match) return undefined;
-
-      const [, node, type, id] = match;
-      return {
-        id,
-        type,
-        node: node === 'local' ? undefined : node,
-        path: key,
-      };
-    } catch (error) {
-      log.error('Failed to parse address key', { key, error });
+      return parseActorPath(key);
+    } catch {
       return undefined;
     }
   }

--- a/packages/actor-core-runtime/src/integration/actor-system-guardian.test.ts
+++ b/packages/actor-core-runtime/src/integration/actor-system-guardian.test.ts
@@ -22,7 +22,7 @@ describe('Guardian Actor - Pure Actor Model', () => {
         id: 'guardian',
         address: {
           id: 'guardian',
-          type: 'system',
+          kind: 'actor',
           node: 'local',
           path: '/system/guardian',
         },
@@ -195,7 +195,7 @@ describe('Guardian Actor - Pure Actor Model', () => {
       expect(guardian).toBeDefined();
       expect(guardian?.address).toEqual({
         id: 'guardian',
-        type: 'system',
+        kind: 'actor',
         node: 'local',
         path: '/system/guardian',
       });

--- a/packages/actor-core-runtime/src/integration/event-emission-debug.test.ts
+++ b/packages/actor-core-runtime/src/integration/event-emission-debug.test.ts
@@ -80,7 +80,7 @@ describe('Event Emission - Debug Multiple Subscribers', () => {
       };
     }
     const registry = (system as unknown as TestActorSystem).autoPublishingRegistry;
-    const metadata1 = registry.getPublishableActor('actor://test-node/actor/publisher');
+    const metadata1 = registry.getPublishableActor('actor://test-node/publisher');
     log.debug('After sub1 subscription:', {
       subscribers: Array.from(metadata1.subscribers.entries()),
     });
@@ -92,7 +92,7 @@ describe('Event Emission - Debug Multiple Subscribers', () => {
     });
 
     // Check registry state after second subscription
-    const metadata2 = registry.getPublishableActor('actor://test-node/actor/publisher');
+    const metadata2 = registry.getPublishableActor('actor://test-node/publisher');
     log.debug('After sub2 subscription:', {
       subscribers: Array.from(metadata2.subscribers.entries()),
     });

--- a/packages/actor-core-runtime/src/integration/guardian-integration.test.ts
+++ b/packages/actor-core-runtime/src/integration/guardian-integration.test.ts
@@ -21,7 +21,7 @@ describe('Guardian Actor Integration', () => {
     // Create mock actor system
     mockActorSystem = {
       spawn: vi.fn().mockResolvedValue({
-        address: { id: 'guardian', type: 'system', node: 'local', path: '/system/guardian' },
+        address: { id: 'guardian', kind: 'actor', node: 'local', path: '/system/guardian' },
         send: vi.fn().mockImplementation((message) => {
           // Track shutdown messages
           if (message.type === 'SHUTDOWN') {
@@ -69,7 +69,7 @@ describe('Guardian Actor Integration', () => {
     it('should create Guardian with correct address', () => {
       expect(guardian.address).toEqual({
         id: 'guardian',
-        type: 'system',
+        kind: 'actor',
         node: 'local',
         path: '/system/guardian',
       });

--- a/packages/actor-core-runtime/src/runtime-gateway.ts
+++ b/packages/actor-core-runtime/src/runtime-gateway.ts
@@ -437,7 +437,7 @@ function replayFrameAddress(frame: RuntimeGatewayReplayFrame): ActorAddress | nu
 }
 
 function addressesMatch(left: ActorAddress, right: ActorAddress): boolean {
-  return left.id === right.id && left.type === right.type && left.path === right.path;
+  return left.id === right.id && left.kind === right.kind && left.path === right.path;
 }
 
 function restoredReplayFramesMatchSource(

--- a/packages/actor-core-runtime/src/topology.ts
+++ b/packages/actor-core-runtime/src/topology.ts
@@ -23,6 +23,7 @@ import {
   defineBehavior as defineTopologyActorBehavior,
   type UnifiedActorBuilder,
 } from './unified-actor-builder.js';
+import { createActorAddress } from './utils/factories.js';
 
 /**
  * Topology aliases of the runtime supervision types (one definition, shared
@@ -34,7 +35,7 @@ export type ActorWebSupervisionPolicy = ActorSupervisionPolicy;
 
 export interface ActorWebActorAddress {
   readonly id: string;
-  readonly type: 'actor';
+  readonly kind: 'actor';
   readonly node: string;
   readonly path: string;
 }
@@ -558,18 +559,15 @@ export function defineActorWebTopology<TInput extends ActorWebTopologyInput>(
       const descriptorId = typeof actorId === 'function' ? key : actorId;
       const resolveAddress = (params?: unknown): ActorWebActorAddress => {
         const id = resolveId(params);
-        return {
-          id,
-          type: 'actor',
-          node: nodeDefinition.address,
-          path: `actor://${nodeDefinition.address}/actor/${id}`,
-        };
+        const a = createActorAddress(id, nodeDefinition.address);
+        return { id: a.id, kind: 'actor', node: nodeDefinition.address, path: a.path };
       };
+      const built = createActorAddress(descriptorId, nodeDefinition.address);
       const address: ActorWebActorAddress = {
-        id: descriptorId,
-        type: 'actor',
+        id: built.id,
+        kind: 'actor',
         node: nodeDefinition.address,
-        path: `actor://${nodeDefinition.address}/actor/${descriptorId}`,
+        path: built.path,
       };
       const { gateway: gatewayDefinition, ...actorDefinition } = definition;
       const gateway =

--- a/packages/actor-core-runtime/src/topology.ts
+++ b/packages/actor-core-runtime/src/topology.ts
@@ -560,13 +560,13 @@ export function defineActorWebTopology<TInput extends ActorWebTopologyInput>(
       const resolveAddress = (params?: unknown): ActorWebActorAddress => {
         const id = resolveId(params);
         const a = createActorAddress(id, nodeDefinition.address);
-        return { id: a.id, kind: 'actor', node: nodeDefinition.address, path: a.path };
+        return { id: a.id, kind: 'actor', node: a.node ?? 'local', path: a.path };
       };
       const built = createActorAddress(descriptorId, nodeDefinition.address);
       const address: ActorWebActorAddress = {
         id: built.id,
         kind: 'actor',
-        node: nodeDefinition.address,
+        node: built.node ?? 'local',
         path: built.path,
       };
       const { gateway: gatewayDefinition, ...actorDefinition } = definition;

--- a/packages/actor-core-runtime/src/unit/actor-address.test.ts
+++ b/packages/actor-core-runtime/src/unit/actor-address.test.ts
@@ -70,6 +70,14 @@ describe('createActorAddress (canonical factory)', () => {
     expect(() => createActorAddress('')).toThrow();
     expect(() => createActorAddress('a1', 'n1', 'callback')).not.toThrow();
   });
+
+  it('rejects an actor id colliding with the reserved callback/ prefix', () => {
+    // `/callback/` is the load-bearing delivery discriminator, so an actor id
+    // starting with `callback/` is ambiguous and must be rejected to keep the
+    // mint -> parse round-trip lossless (a real callback kind is still allowed).
+    expect(() => createActorAddress('callback/c1')).toThrow(/reserved/i);
+    expect(() => createActorAddress('c1', 'n1', 'callback')).not.toThrow();
+  });
 });
 
 describe('parseActorPath', () => {

--- a/packages/actor-core-runtime/src/unit/actor-address.test.ts
+++ b/packages/actor-core-runtime/src/unit/actor-address.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @module actor-core/runtime/unit/actor-address.test
+ * @description Unit tests for the canonical opaque actor-address factory and parser.
+ *
+ * Covers the single minting site (createActorAddress / createLocalActorAddress /
+ * createRemoteActorAddress) and the round-trip parser (parseActorPath). Addresses
+ * are 2-segment for actors (actor://<node>/<id>) and 3-segment for callbacks
+ * (actor://<node>/callback/<id>); `kind` replaces the old `type` field and `node`
+ * is always set.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseActorPath } from '../actor-system.js';
+import {
+  createActorAddress,
+  createLocalActorAddress,
+  createRemoteActorAddress,
+} from '../utils/factories.js';
+
+describe('createActorAddress (canonical factory)', () => {
+  it('mints a 2-segment actor address with node defaulted to local', () => {
+    const address = createActorAddress('a1');
+    expect(address).toEqual({
+      id: 'a1',
+      kind: 'actor',
+      node: 'local',
+      path: 'actor://local/a1',
+    });
+    // The redundant /actor/ segment is dropped for actors.
+    expect(address.path).not.toContain('/actor/');
+  });
+
+  it('createLocalActorAddress deep-equals the defaulted factory output', () => {
+    expect(createLocalActorAddress('a1')).toEqual(createActorAddress('a1'));
+  });
+
+  it('createRemoteActorAddress carries the concrete node', () => {
+    const address = createRemoteActorAddress('a1', 'n2');
+    expect(address).toEqual({
+      id: 'a1',
+      kind: 'actor',
+      node: 'n2',
+      path: 'actor://n2/a1',
+    });
+  });
+
+  it('always sets node on factory output (local and remote)', () => {
+    expect(createActorAddress('a1').node).toBe('local');
+    expect(createActorAddress('a1', 'n2').node).toBe('n2');
+    expect(createLocalActorAddress('a1').node).toBe('local');
+    expect(createRemoteActorAddress('a1', 'n2').node).toBe('n2');
+  });
+
+  it('mints a 3-segment callback address with kind=callback', () => {
+    const address = createActorAddress('c1', 'n1', 'callback');
+    expect(address).toEqual({
+      id: 'c1',
+      kind: 'callback',
+      node: 'n1',
+      path: 'actor://n1/callback/c1',
+    });
+  });
+
+  it('preserves slash-bearing ids in the path', () => {
+    const address = createActorAddress('group/sub', 'n1');
+    expect(address.path).toBe('actor://n1/group/sub');
+  });
+
+  it('throws on an empty id but not on a valid callback', () => {
+    expect(() => createActorAddress('')).toThrow();
+    expect(() => createActorAddress('a1', 'n1', 'callback')).not.toThrow();
+  });
+});
+
+describe('parseActorPath', () => {
+  it('parses a 2-segment actor path with node always defined (local)', () => {
+    const address = parseActorPath('actor://local/a1');
+    expect(address).toEqual({
+      id: 'a1',
+      kind: 'actor',
+      node: 'local',
+      path: 'actor://local/a1',
+    });
+    expect(address.node).toBe('local');
+  });
+
+  it('parses a remote 2-segment actor path', () => {
+    const address = parseActorPath('actor://n2/a1');
+    expect(address).toMatchObject({ id: 'a1', kind: 'actor', node: 'n2' });
+  });
+
+  it('matches the callback pattern first (id is not "callback/...")', () => {
+    const address = parseActorPath('actor://n1/callback/c1');
+    expect(address).toMatchObject({ id: 'c1', kind: 'callback', node: 'n1' });
+    expect(address.id).not.toBe('callback/c1');
+  });
+
+  it('round-trips an actor address through the factory', () => {
+    const minted = createActorAddress('a1', 'n2');
+    expect(parseActorPath(minted.path)).toEqual(minted);
+  });
+
+  it('round-trips a callback address through the factory', () => {
+    const minted = createActorAddress('c1', 'n1', 'callback');
+    expect(parseActorPath(minted.path)).toEqual(minted);
+  });
+
+  it('round-trips a slash-bearing id', () => {
+    const minted = createActorAddress('group/sub', 'n1');
+    expect(parseActorPath(minted.path)).toEqual(minted);
+    expect(parseActorPath(minted.path).id).toBe('group/sub');
+  });
+
+  it('throws on a malformed path', () => {
+    expect(() => parseActorPath('not-an-actor-path')).toThrow();
+  });
+});

--- a/packages/actor-core-runtime/src/unit/actor-source.test.ts
+++ b/packages/actor-core-runtime/src/unit/actor-source.test.ts
@@ -67,7 +67,7 @@ describe('actor source', () => {
   it('projects Actor-Web snapshots into host-ready snapshots with address and phase', () => {
     const address = {
       id: 'checkout',
-      type: 'unified',
+      kind: 'actor' as const,
       path: '/actors/checkout',
     };
 
@@ -99,7 +99,7 @@ describe('actor source', () => {
       } as unknown as ActorInstance,
       {
         id: 'typed-counter',
-        type: 'actor',
+        kind: 'actor',
         path: '/actors/typed-counter',
       }
     );
@@ -252,8 +252,8 @@ describe('actor source', () => {
     const remoteActor = {
       address: {
         id: 'checkout-remote',
-        type: 'actor',
-        path: 'actor://remote-node/actor/checkout-remote',
+        kind: 'actor' as const,
+        path: 'actor://remote-node/checkout-remote',
       },
       getSnapshot: () => createSnapshot(undefined, { count: -1 }),
       send: async () => {},

--- a/packages/actor-core-runtime/src/unit/actor-tools.test.ts
+++ b/packages/actor-core-runtime/src/unit/actor-tools.test.ts
@@ -24,7 +24,7 @@ describe('ActorToolbox', () => {
         'provider.secret': () => 'hidden',
       },
       {
-        actorId: 'actor://worker/actor/scanner',
+        actorId: 'actor://worker/scanner',
         nodeAddress: 'worker',
       },
       ['provider.scan.verify']
@@ -34,12 +34,12 @@ describe('ActorToolbox', () => {
 
     expect(result).toEqual({
       accepted: true,
-      label: 'actor://worker/actor/scanner:HVAC',
+      label: 'actor://worker/scanner:HVAC',
     });
     expect(scan).toHaveBeenCalledWith(
       { label: 'HVAC' },
       {
-        actorId: 'actor://worker/actor/scanner',
+        actorId: 'actor://worker/scanner',
         nodeAddress: 'worker',
       }
     );
@@ -54,7 +54,7 @@ describe('ActorToolbox', () => {
         'provider.secret': () => 'hidden',
       },
       {
-        actorId: 'actor://worker/actor/scanner',
+        actorId: 'actor://worker/scanner',
         nodeAddress: 'worker',
       },
       ['provider.scan.verify']
@@ -115,7 +115,7 @@ describe('ActorToolbox', () => {
         'provider.secret': () => 'hidden',
       },
       {
-        actorId: 'actor://worker/actor/scanner',
+        actorId: 'actor://worker/scanner',
         nodeAddress: 'worker',
       },
       scanActor.tools
@@ -126,7 +126,7 @@ describe('ActorToolbox', () => {
     )?.onMessage?.({
       message: { type: 'SCAN', label: 'HVAC' },
       actor: {
-        id: 'actor://worker/actor/scanner',
+        id: 'actor://worker/scanner',
         getSnapshot: () => ({ context: undefined }),
       },
       tools: toolbox,
@@ -138,7 +138,7 @@ describe('ActorToolbox', () => {
     expect(result).toMatchObject({
       reply: {
         accepted: true,
-        label: 'actor://worker/actor/scanner:HVAC',
+        label: 'actor://worker/scanner:HVAC',
       },
     });
     expect(scan).toHaveBeenCalledOnce();

--- a/packages/actor-core-runtime/src/unit/actor-web-source.test.ts
+++ b/packages/actor-core-runtime/src/unit/actor-web-source.test.ts
@@ -53,7 +53,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     const source = createActorWebSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -186,7 +186,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     const source = createActorWebReadModelSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -199,7 +199,7 @@ describe('createActorWebSource', () => {
     );
     const commandSource = createActorWebCommandSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -225,7 +225,7 @@ describe('createActorWebSource', () => {
     const commandSocket = new FakeGatewaySocket();
     const readModel = createActorWebReadModelSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -238,7 +238,7 @@ describe('createActorWebSource', () => {
     );
     const commandSource = createActorWebCommandSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -298,7 +298,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     createActorWebSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           auth: {
@@ -329,7 +329,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     createActorWebSource(
       {
-        address: 'actor://server-node/actor/vehicle-inspections',
+        address: 'actor://server-node/vehicle-inspections',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: {
@@ -371,7 +371,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     createActorWebSource(
       {
-        address: 'actor://server-node/actor/vehicle-inspections',
+        address: 'actor://server-node/vehicle-inspections',
         gateway: {
           url: 'ws://gateway.local/runtime',
         },
@@ -403,7 +403,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     const source = createActorWebSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -510,7 +510,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     const source = createActorWebSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -569,7 +569,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     const source = createActorWebSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -649,7 +649,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     const source = createActorWebCommandSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },
@@ -694,7 +694,7 @@ describe('createActorWebSource', () => {
     const socket = new FakeGatewaySocket();
     const source = createActorWebCommandSource(
       {
-        address: 'actor://server-node/actor/shipment',
+        address: 'actor://server-node/shipment',
         gateway: {
           url: 'ws://gateway.local/runtime',
           scope: { kind: 'shipment' },

--- a/packages/actor-core-runtime/src/unit/auto-publishing-actual.test.ts
+++ b/packages/actor-core-runtime/src/unit/auto-publishing-actual.test.ts
@@ -13,7 +13,7 @@ function createMockActorRef(path: string): ActorRef {
   return {
     address: {
       id: path.split('/').pop() || 'unknown',
-      type: 'test',
+      kind: 'actor',
       path,
       node: 'test-node',
     },

--- a/packages/actor-core-runtime/src/unit/component-runtime-ownership.test.ts
+++ b/packages/actor-core-runtime/src/unit/component-runtime-ownership.test.ts
@@ -63,7 +63,7 @@ function createActorRef(path: string): ActorRef {
   return {
     address: {
       id: path.split('/').at(-1) ?? path,
-      type: 'actor',
+      kind: 'actor',
       path,
     },
     send: vi.fn(async (_message: ActorMessage<{ type: string }>) => undefined),
@@ -87,7 +87,7 @@ function createRuntimeMock(label: string): {
   stop: ReturnType<typeof vi.fn>;
   actorRef: ActorRef;
 } {
-  const actorRef = createActorRef(`actor://${label}/actor/component-actor`);
+  const actorRef = createActorRef(`actor://${label}/component-actor`);
   const spawn = vi.fn(async () => actorRef);
   const lookup = vi.fn(async (path: string) => createActorRef(path));
   const start = vi.fn(async () => undefined);
@@ -161,7 +161,7 @@ describe('component runtime ownership', () => {
       machine,
       template,
       runtime: runtimeProvider,
-      dependencies: { backend: 'actor://config-runtime/actor/backend' },
+      dependencies: { backend: 'actor://config-runtime/backend' },
     });
 
     const element = component.create() as InternalComponentElement;
@@ -180,7 +180,7 @@ describe('component runtime ownership', () => {
       machine,
       template,
       runtime: configRuntime.runtime,
-      dependencies: { backend: 'actor://override-runtime/actor/backend' },
+      dependencies: { backend: 'actor://override-runtime/backend' },
     });
 
     const element = component.create({
@@ -197,7 +197,7 @@ describe('component runtime ownership', () => {
   it('supports a per-call runtime override for createWithDependencies', async () => {
     const configRuntime = createRuntimeMock('config-runtime');
     const overrideRuntime = createRuntimeMock('override-runtime');
-    const injectedDependency = createActorRef('actor://override-runtime/actor/injected');
+    const injectedDependency = createActorRef('actor://override-runtime/injected');
     const component = createComponent({
       machine,
       template,
@@ -216,7 +216,7 @@ describe('component runtime ownership', () => {
       expect.objectContaining({
         type: 'UPDATE_DEPENDENCIES',
         dependencyRefs: {
-          injected: 'actor://override-runtime/actor/injected',
+          injected: 'actor://override-runtime/injected',
         },
       })
     );
@@ -246,7 +246,7 @@ describe('component runtime ownership', () => {
     const component = createComponent({
       machine,
       template,
-      dependencies: { backend: 'actor://fallback-runtime/actor/backend' },
+      dependencies: { backend: 'actor://fallback-runtime/backend' },
     });
 
     const firstElement = component.create() as InternalComponentElement;

--- a/packages/actor-core-runtime/src/unit/cross-node-subscription-delivery.test.ts
+++ b/packages/actor-core-runtime/src/unit/cross-node-subscription-delivery.test.ts
@@ -296,7 +296,7 @@ describe('cross-node topology subscription delivery', () => {
     publisherSystem.registerTopologyRemoteSubscriber({
       publisherPath: publisher.address.path,
       subscriberNode: 'ghost-node',
-      subscriberPath: 'actor://ghost-node/actor/sub',
+      subscriberPath: 'actor://ghost-node/sub',
     });
 
     // The drop is an operator-facing telemetry contract — pin the warn line so a
@@ -311,7 +311,7 @@ describe('cross-node topology subscription delivery', () => {
         'Cross-node subscription event dropped',
         expect.objectContaining({
           publisherPath: publisher.address.path,
-          subscriberPath: 'actor://ghost-node/actor/sub',
+          subscriberPath: 'actor://ghost-node/sub',
           node: 'ghost-node',
           eventType: 'TICK',
         })
@@ -344,7 +344,7 @@ describe('cross-node topology subscription delivery', () => {
           type: '__runtime.topology.event',
           subscriberPath: 'not-a-valid-actor-path',
           payload: {
-            address: { id: 'x', type: 'actor', node: 'node-a', path: 'p' },
+            address: { id: 'x', kind: 'actor', node: 'node-a', path: 'p' },
             envelope: {},
             sequence: 0,
           },
@@ -415,8 +415,8 @@ describe('wireOwnedActorWebSubscriptions cross-node branch', () => {
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
         publisherNode: 'server',
-        publisherPath: 'actor://server/actor/pub',
-        subscriberPath: 'actor://worker/actor/sub',
+        publisherPath: 'actor://server/pub',
+        subscriberPath: 'actor://worker/sub',
         events: ['TICK'],
       })
     );

--- a/packages/actor-core-runtime/src/unit/cross-node-subscription-integration.test.ts
+++ b/packages/actor-core-runtime/src/unit/cross-node-subscription-integration.test.ts
@@ -60,8 +60,8 @@ async function pollUntil(
   return received;
 }
 
-const PUB_PATH = 'actor://node-a/actor/pub';
-const SUB_PATH = 'actor://node-b/actor/sub';
+const PUB_PATH = 'actor://node-a/pub';
+const SUB_PATH = 'actor://node-b/sub';
 
 describe('cross-node subscription delivery (multi-node)', () => {
   let nodeA: ActorSystemImpl | undefined;

--- a/packages/actor-core-runtime/src/unit/distributed-actor-directory.test.ts
+++ b/packages/actor-core-runtime/src/unit/distributed-actor-directory.test.ts
@@ -16,12 +16,8 @@ const log = Logger.namespace('TEST');
 // Use `pnpm test:debug` for verbose output when needed
 
 function createActorAddress(id: string, type: string, node: string): ActorAddress {
-  return {
-    id,
-    type,
-    node,
-    path: `actor://${node}/${type}/${id}`,
-  };
+  void type; // retained for call-site compatibility; addresses are now 2-segment (kind replaces type)
+  return { id, kind: 'actor', node, path: `actor://${node}/${id}` };
 }
 
 describe.skip('DistributedActorDirectory', () => {

--- a/packages/actor-core-runtime/src/unit/message-plan.test.ts
+++ b/packages/actor-core-runtime/src/unit/message-plan.test.ts
@@ -30,7 +30,7 @@ import { isActorMessage, isDomainEvent, isMessagePlan } from '../utils/validatio
 // ============================================================================
 
 const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-  address: { id: 'test-actor', type: 'test', path: '/test-actor' },
+  address: { id: 'test-actor', kind: 'actor', path: '/test-actor' },
   send: vi.fn().mockResolvedValue(undefined),
   ask: vi.fn().mockResolvedValue({ success: true }),
 });

--- a/packages/actor-core-runtime/src/unit/message-plan.unit.test.ts
+++ b/packages/actor-core-runtime/src/unit/message-plan.unit.test.ts
@@ -39,7 +39,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
 
     it('should identify SendInstruction correctly', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'actor-123', type: 'test', path: '/actor-123' },
+        address: { id: 'actor-123', kind: 'actor', path: '/actor-123' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });
@@ -58,7 +58,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
 
     it('should identify AskInstruction correctly', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'actor-123', type: 'test', path: '/actor-123' },
+        address: { id: 'actor-123', kind: 'actor', path: '/actor-123' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });
@@ -80,7 +80,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
       const domainEvent: DomainEvent = { type: 'TEST_EVENT', timestamp: Date.now() };
 
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: '123', type: 'test', path: '/123' },
+        address: { id: '123', kind: 'actor', path: '/123' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });
@@ -111,7 +111,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
   describe('Factory Functions', () => {
     it('should create SendInstruction with correct structure', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'test-actor', type: 'test', path: '/test-actor' },
+        address: { id: 'test-actor', kind: 'actor', path: '/test-actor' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });
@@ -133,7 +133,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
 
     it('should create SendInstruction with explicit fireAndForget mode', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'test-actor', type: 'test', path: '/test-actor' },
+        address: { id: 'test-actor', kind: 'actor', path: '/test-actor' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });
@@ -152,7 +152,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
 
     it('should create AskInstruction with correct structure', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'test-actor', type: 'test', path: '/test-actor' },
+        address: { id: 'test-actor', kind: 'actor', path: '/test-actor' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({ result: 'success' }) as T,
       });
@@ -181,7 +181,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
 
     it('should create AskInstruction with custom timeout', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'test-actor', type: 'test', path: '/test-actor' },
+        address: { id: 'test-actor', kind: 'actor', path: '/test-actor' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });
@@ -208,7 +208,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
 
     it('should handle timeout in createAskInstruction', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'test-actor', type: 'test', path: '/test-actor' },
+        address: { id: 'test-actor', kind: 'actor', path: '/test-actor' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });
@@ -235,7 +235,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
 
     it('should handle error callback in createAskInstruction', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'test-actor', type: 'test', path: '/test-actor' },
+        address: { id: 'test-actor', kind: 'actor', path: '/test-actor' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });
@@ -262,7 +262,7 @@ describe('MessagePlan Utility Functions (Unit Tests)', () => {
 
     it('should validate both onOk and onError in createAskInstruction', () => {
       const mockActorRef: ActorRef<ActorMessage> = createMockActorRef({
-        address: { id: 'test-actor', type: 'test', path: '/test-actor' },
+        address: { id: 'test-actor', kind: 'actor', path: '/test-actor' },
         send: async () => {},
         ask: async <T>(): Promise<T> => ({}) as T,
       });

--- a/packages/actor-core-runtime/src/unit/plan-interpreter.test.ts
+++ b/packages/actor-core-runtime/src/unit/plan-interpreter.test.ts
@@ -35,7 +35,7 @@ const mockDomainEvent: DomainEvent = {
 
 const createMockActorRef = (): ActorRef =>
   createMockActorRefUtil({
-    address: { id: 'mock-actor', type: 'test', path: '/mock-actor' },
+    address: { id: 'mock-actor', kind: 'actor', path: '/mock-actor' },
     send: vi.fn().mockResolvedValue(undefined),
     ask: vi.fn().mockResolvedValue({ success: true }),
   });

--- a/packages/actor-core-runtime/src/unit/runtime-gateway.test.ts
+++ b/packages/actor-core-runtime/src/unit/runtime-gateway.test.ts
@@ -202,7 +202,7 @@ function createGatewaySnapshot(
   return {
     address: {
       id: `actor-${actorKey}`,
-      type: 'actor',
+      kind: 'actor',
       path: `/actors/${actorKey}`,
     },
     snapshot: {
@@ -222,7 +222,7 @@ function createGatewaySnapshot(
 function createGatewayAddress(actorKey: string) {
   return {
     id: `actor-${actorKey}`,
-    type: 'actor' as const,
+    kind: 'actor' as const,
     path: `/actors/${actorKey}`,
   };
 }

--- a/packages/actor-core-runtime/src/unit/runtime-gateway.test.ts
+++ b/packages/actor-core-runtime/src/unit/runtime-gateway.test.ts
@@ -725,7 +725,7 @@ describe('runtime gateway source', () => {
     expect(events[0]?.envelope).toMatchObject({
       kind: 'fact',
       type: 'CHECKOUT_SUBMITTED',
-      sourceActor: '/actors/gateway-checkout',
+      sourceActor: 'actor://local/gateway-checkout',
     });
     expect(transitions).toEqual([{ fromState: 'ready', toState: 'submitted' }]);
   });

--- a/packages/actor-core-runtime/src/unit/runtime-projection.test.ts
+++ b/packages/actor-core-runtime/src/unit/runtime-projection.test.ts
@@ -38,7 +38,7 @@ describe('runtime projection mappings', () => {
       _timestamp: 101,
       _version: '1',
       _correlationId: 'corr-1',
-      _sender: { id: 'actor-1', type: 'worker', path: '/actor-1' },
+      _sender: { id: 'actor-1', kind: 'actor' as const, path: '/actor-1' },
     };
 
     const envelope = actorMessageToEventEnvelope(message, {
@@ -71,7 +71,7 @@ describe('runtime projection mappings', () => {
       _timestamp: 200,
       _version: '1',
       _correlationId: 'corr-2',
-      _sender: { id: 'actor-2', type: 'system', path: '/actor-2' },
+      _sender: { id: 'actor-2', kind: 'actor' as const, path: '/actor-2' },
     };
     const envelope = actorMessageToEventEnvelope(message, {
       id: 'event-2',
@@ -92,7 +92,7 @@ describe('runtime projection mappings', () => {
         _timestamp: 200,
         _version: '1',
         _correlationId: 'corr-2',
-        _sender: { id: 'actor-2', type: 'system', path: '/actor-2' },
+        _sender: { id: 'actor-2', kind: 'actor', path: '/actor-2' },
       })
     ).toEqual({ value: 42 });
   });

--- a/packages/actor-core-runtime/src/unit/serve-actor-web-node.test.ts
+++ b/packages/actor-core-runtime/src/unit/serve-actor-web-node.test.ts
@@ -138,7 +138,7 @@ describe('serveNode', () => {
     try {
       expect(served.getTransportUrl()).toMatch(/^ws:\/\/127\.0\.0\.1:/);
       expect(served.getGatewayUrl()).toMatch(/^ws:\/\/127\.0\.0\.1:/);
-      expect(served.getActor('counter')?.address.path).toBe('actor://server-node/actor/counter');
+      expect(served.getActor('counter')?.address.path).toBe('actor://server-node/counter');
       expect(served.getActor('workerCounter')).toBeUndefined();
       expect(() => served.requireActor('workerCounter')).toThrow(
         'Actor-Web node did not spawn actor "workerCounter".'
@@ -171,7 +171,7 @@ describe('serveNode', () => {
         streamId: 'counter-stream',
         projection: {
           address: {
-            path: 'actor://server-node/actor/counter',
+            path: 'actor://server-node/counter',
           },
           context: {
             count: 1,
@@ -431,7 +431,7 @@ describe('serveNode', () => {
         streamId: 'worker-counter-stream',
         projection: {
           address: {
-            path: 'actor://worker-node/actor/worker-counter',
+            path: 'actor://worker-node/worker-counter',
           },
           context: {
             count: 1,
@@ -567,13 +567,13 @@ describe('serveNode', () => {
       expect(served.getActor('shipment')).toBeUndefined();
       expect(topology.actors.shipment.resolveAddress({ shipmentId: '1001' })).toMatchObject({
         id: 'shipment-1001',
-        path: 'actor://server-node/actor/shipment-1001',
+        path: 'actor://server-node/shipment-1001',
       });
 
       const first = await served.actors.shipment.instance({ shipmentId: '1001' });
       const second = await served.actors.shipment.instance({ shipmentId: '1001' });
       expect(second).toBe(first);
-      expect(first.address.path).toBe('actor://server-node/actor/shipment-1001');
+      expect(first.address.path).toBe('actor://server-node/shipment-1001');
 
       await first.send({ type: 'INCREMENT' });
       await served.system.flush();
@@ -838,11 +838,11 @@ describe('serveNode', () => {
         'Expected worker peer to connect before stopping it'
       );
       await waitFor(
-        () => served.system.lookup('actor://worker-node/actor/worker-counter'),
+        () => served.system.lookup('actor://worker-node/worker-counter'),
         'Expected server node to finish syncing the worker directory before stopping the peer'
       );
       await waitFor(
-        () => worker.system.lookup('actor://server-node/actor/server-counter'),
+        () => worker.system.lookup('actor://server-node/server-counter'),
         'Expected worker node to finish syncing the server directory before stopping the peer'
       );
 

--- a/packages/actor-core-runtime/src/unit/start-actor-web-node.test.ts
+++ b/packages/actor-core-runtime/src/unit/start-actor-web-node.test.ts
@@ -120,7 +120,7 @@ describe('startActorWebNode', () => {
         'Actor-Web node did not spawn actor "serverCounter".'
       );
       expect(workerNode.getActor('workerCounter')?.address.path).toBe(
-        'actor://worker-node/actor/worker-counter'
+        'actor://worker-node/worker-counter'
       );
       expect(workerNode.transport.getConnectedNodes()).toEqual([]);
 
@@ -363,7 +363,7 @@ describe('startActorWebNode', () => {
       expect(workerNode.getActor('task')).toBeUndefined();
 
       const task = await workerNode.actors.task.instance({ taskId: 'route-1001' });
-      expect(task.address.path).toBe('actor://worker-node/actor/task-route-1001');
+      expect(task.address.path).toBe('actor://worker-node/task-route-1001');
       await task.send({ type: 'INCREMENT' });
       await workerNode.system.flush();
       await expect(task.ask<number>({ type: 'GET_COUNT' })).resolves.toBe(1);

--- a/packages/actor-core-runtime/src/unit/supervisor-trees.test.ts
+++ b/packages/actor-core-runtime/src/unit/supervisor-trees.test.ts
@@ -23,9 +23,9 @@ import {
 } from '../actor-system-impl.js';
 import { defineBehavior } from '../unified-actor-builder.js';
 
-const PATH_A = 'actor://supervisor-trees-test/actor/a';
-const PATH_B = 'actor://supervisor-trees-test/actor/b';
-const PATH_C = 'actor://supervisor-trees-test/actor/c';
+const PATH_A = 'actor://supervisor-trees-test/a';
+const PATH_B = 'actor://supervisor-trees-test/b';
+const PATH_C = 'actor://supervisor-trees-test/c';
 
 function group(
   strategy: SupervisorGroupConfig['strategy'],
@@ -188,7 +188,7 @@ describe('resolveTreeSupervisionDecision (pure tree core)', () => {
       resolveTreeSupervisionDecision({
         childDecision: RESTART_DECISION,
         group: group('one-for-all'),
-        failedChildPath: 'actor://supervisor-trees-test/actor/stranger',
+        failedChildPath: 'actor://supervisor-trees-test/stranger',
       })
     ).toEqual({ kind: 'pass-through' });
   });
@@ -290,7 +290,7 @@ describe('supervisor group failure path (behavioral)', () => {
   let emitSystemEventSpy: MockInstance<any>;
 
   function pathOf(id: string): string {
-    return `actor://${NODE}/actor/${id}`;
+    return `actor://${NODE}/${id}`;
   }
 
   async function makeSystem(supervisors: SupervisorGroupConfig[]): Promise<void> {
@@ -769,7 +769,7 @@ describe('supervisor group failure path (behavioral)', () => {
       try {
         // biome-ignore lint/suspicious/noExplicitAny: Testing private methods requires any
         await (system as any).applySupervisionStrategy(
-          { id: 'guard-a', type: 'actor', node: NODE, path: pathOf('guard-a') },
+          { id: 'guard-a', kind: 'actor', node: NODE, path: pathOf('guard-a') },
           new Error('induced during group action')
         );
       } finally {

--- a/packages/actor-core-runtime/src/unit/system-event-actor-processing.test.ts
+++ b/packages/actor-core-runtime/src/unit/system-event-actor-processing.test.ts
@@ -22,7 +22,7 @@ describe('Layer 2: System Event Actor Processing', () => {
     await system.start();
 
     // System event actor address
-    systemEventActorAddress = { path: 'actor://test-node/actor/system-event-actor' };
+    systemEventActorAddress = { path: 'actor://test-node/system-event-actor' };
   });
 
   afterEach(async () => {
@@ -72,7 +72,7 @@ describe('Layer 2: System Event Actor Processing', () => {
           type: 'EMIT_SYSTEM_EVENT',
           systemEventType: 'actorSpawned',
           systemTimestamp: Date.now(),
-          systemData: { address: 'actor://test-node/actor/test' },
+          systemData: { address: 'actor://test-node/test' },
           _timestamp: Date.now(),
           _version: '1.0.0',
         },
@@ -95,13 +95,13 @@ describe('Layer 2: System Event Actor Processing', () => {
       expect(inst1).toHaveProperty('tell');
       expect(inst1.tell.type).toBe('SYSTEM_EVENT_NOTIFICATION');
       expect(inst1.tell.eventType).toBe('actorSpawned');
-      expect(inst1.tell.data).toEqual({ address: 'actor://test-node/actor/test' });
+      expect(inst1.tell.data).toEqual({ address: 'actor://test-node/test' });
 
       expect(inst2).toHaveProperty('to');
       expect(inst2).toHaveProperty('tell');
       expect(inst2.tell.type).toBe('SYSTEM_EVENT_NOTIFICATION');
       expect(inst2.tell.eventType).toBe('actorSpawned');
-      expect(inst2.tell.data).toEqual({ address: 'actor://test-node/actor/test' });
+      expect(inst2.tell.data).toEqual({ address: 'actor://test-node/test' });
 
       log.info('✅ System event actor returns correct send instructions');
     });

--- a/packages/actor-core-runtime/src/unit/topology.test.ts
+++ b/packages/actor-core-runtime/src/unit/topology.test.ts
@@ -79,9 +79,9 @@ describe('Actor-Web topology helpers', () => {
     expect(logistics.nodes.server.address).toBe('logistics-server-runtime');
     expect(logistics.actors.shipment.address).toEqual({
       id: 'logistics-shipment',
-      type: 'actor',
+      kind: 'actor',
       node: 'logistics-server-runtime',
-      path: 'actor://logistics-server-runtime/actor/logistics-shipment',
+      path: 'actor://logistics-server-runtime/logistics-shipment',
     });
     expect(logistics.actors.shipment.nodeAddress).toBe('logistics-server-runtime');
     expect(logistics.tools['route.plan']).toEqual({

--- a/packages/actor-core-runtime/src/utils/factories.ts
+++ b/packages/actor-core-runtime/src/utils/factories.ts
@@ -64,6 +64,12 @@ export function createActorAddress(
   if (!id || typeof id !== 'string') {
     throw new Error('Actor ID must be a non-empty string'); // KEEP: value-object precondition
   }
+  // `/callback/` is the load-bearing delivery discriminator (parseActorPath matches it
+  // first), so an actor id starting with `callback/` would round-trip back as
+  // kind:'callback' and misroute. Reserve the prefix for actor-kind ids.
+  if (kind === 'actor' && id.startsWith('callback/')) {
+    throw new Error(`Actor id must not start with the reserved "callback/" prefix: ${id}`);
+  }
   const resolvedNode = node || 'local'; // single node-normalization site; node ALWAYS set
   const path =
     kind === 'callback'

--- a/packages/actor-core-runtime/src/utils/factories.ts
+++ b/packages/actor-core-runtime/src/utils/factories.ts
@@ -56,36 +56,34 @@ export function generateSystemId(): string {
 /**
  * Creates actor address for location transparency
  */
-export function createActorAddress(id: string, type: string, node?: string): ActorAddress {
+export function createActorAddress(
+  id: string,
+  node?: string,
+  kind: 'actor' | 'callback' = 'actor'
+): ActorAddress {
   if (!id || typeof id !== 'string') {
-    throw new Error('Actor ID must be a non-empty string');
+    throw new Error('Actor ID must be a non-empty string'); // KEEP: value-object precondition
   }
-
-  if (!type || typeof type !== 'string') {
-    throw new Error('Actor type must be a non-empty string');
-  }
-
-  const actualNode = node || 'local';
-  return {
-    id,
-    type,
-    node: actualNode,
-    path: `actor://${actualNode}/${type}/${id}`,
-  };
+  const resolvedNode = node || 'local'; // single node-normalization site; node ALWAYS set
+  const path =
+    kind === 'callback'
+      ? `actor://${resolvedNode}/callback/${id}`
+      : `actor://${resolvedNode}/${id}`; // 2-segment for actors (drop redundant /actor/)
+  return { id, kind, node: resolvedNode, path };
 }
 
 /**
  * Creates local actor address (same node)
  */
-export function createLocalActorAddress(id: string, type: string): ActorAddress {
-  return createActorAddress(id, type, 'local');
+export function createLocalActorAddress(id: string): ActorAddress {
+  return createActorAddress(id, 'local');
 }
 
 /**
  * Creates remote actor address (different node)
  */
-export function createRemoteActorAddress(id: string, type: string, node: string): ActorAddress {
-  return createActorAddress(id, type, node);
+export function createRemoteActorAddress(id: string, node: string): ActorAddress {
+  return createActorAddress(id, node);
 }
 
 // ============================================================================

--- a/packages/actor-core-runtime/src/utils/null-actor.ts
+++ b/packages/actor-core-runtime/src/utils/null-actor.ts
@@ -22,7 +22,7 @@ export function createNullActorRef(id: string): ActorRef<unknown> {
   return {
     address: {
       id,
-      type: 'null',
+      kind: 'actor',
       node: 'local',
       path: `/null/${id}`,
     },


### PR DESCRIPTION
## Summary

L0 of the location-transparency roadmap: makes actor addresses opaque and mints them through one canonical factory.

- `ActorAddress.type: string` → `kind: 'actor' | 'callback'` (closed union; nothing read the old free-form `type`).
- Actor address paths drop the redundant `/actor/` segment: `actor://<node>/<id>`. Callbacks keep `actor://<node>/callback/<id>` — the `/callback/` routing discriminator is load-bearing and untouched.
- All actor addresses mint through one pure factory `createActorAddress(id, node?, kind?)` with a single canonical local-node normalization (`node` always set; `'local'` the canonical marker). `parseActorPath`, `normalizeAddress`, the directory key parser, and the spawn + topology mint sites all funnel through it. `createLocalActorAddress(id)` / `createRemoteActorAddress(id, node)` drop their former `type` parameter.
- Guardian keeps its well-known special address (`/system/guardian`, `kind: 'actor'`). Reconciling the non-uniform guardian / callback / sentinel addresses is deferred to the unify-directory task.

## Breaking changes

The exported `ActorAddress` / `ActorWebActorAddress` types, the `createActorAddress` signature, and the actor address path format changed (minor bump under the planned 0.2.0; changeset included). **All cluster nodes must upgrade together** — the actor address wire format is not interoperable across this change (callback addresses are unaffected).

## Tests & verification

- New `unit/actor-address.test.ts` (TDD, written first): both kinds, parse round-trip, callback-first match order, node-always-set, slash-bearing ids, empty-id throw.
- ~12 migration test files updated to the 2-segment format; first-party examples updated.
- `verify.sh --full` green: format, lint, typecheck, test, architecture drift, behavior boundaries, semantic index.

## Notes

- Deferred to unify-directory: the guardian / callback / sentinel non-`actor://` addresses, and the `callback/`-prefixed-actor-id parse edge (unreachable today — `generateActorId` only emits `actor-…` ids).
- Spawn debug log field renamed `type` → `kind`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Actor address shape updated: `type` field replaced with `kind: 'actor' | 'callback'`
  * Actor address path format simplified from `actor://<node>/actor/<id>` to `actor://<node>/<id>`
  * Actor addresses must now be created exclusively via canonical factory functions

* **New Features**
  * Centralized actor address factory: `createActorAddress(id, node?, kind?)` with opaque canonical minting
  * Simplified address factory helpers: `createLocalActorAddress(id)` and `createRemoteActorAddress(id, node)`

* **Documentation**
  * Added planning tasks and design documentation for mesh networking, streaming semantics, and transport improvements
  * Location-transparency architecture audit added to spike documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->