### PR TITLE
ci(cli): run agent-workflow-cli tests in CI + migrate trailing .address.path reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,6 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
       - name: Test
-        run: pnpm test
+        run: pnpm test:all
       - name: Architecture boundaries
         run: pnpm architecture:check

--- a/docs/site/guides/multi-process-deployment.md
+++ b/docs/site/guides/multi-process-deployment.md
@@ -47,7 +47,7 @@ or a gateway without peers (a single-node server).
 A node resolves peers' actors by address:
 
 ```ts
-const planner = await coordinator.system.lookup(topology.actors.plannerAgent.address.path);
+const planner = await coordinator.system.lookup(topology.actors.plannerAgent.address);
 await planner.ask({ type: 'PLAN_TASK', taskId });
 ```
 

--- a/packages/agent-workflow-cli/src/host/runtime-host.test.ts
+++ b/packages/agent-workflow-cli/src/host/runtime-host.test.ts
@@ -170,7 +170,7 @@ describe('createRuntimeHost', () => {
   it('resolves targets by key and by actor:// path', async () => {
     const byKey = host.resolve('counter');
     expect(byKey).toBeDefined();
-    const byPath = host.resolve(byKey?.address.path ?? '');
+    const byPath = host.resolve(byKey?.address ?? '');
     expect(byPath).toBe(byKey);
   });
 


### PR DESCRIPTION
Resolves `task-1782336384805` (migration-tail + CI blind-spot follow-up surfaced by the opaque-address PR review).

## What

1. Migrates the two trailing `.address.path` reads the opaque-address migration missed — `agent-workflow-cli/src/host/runtime-host.test.ts` and `docs/site/guides/multi-process-deployment.md` — to the branded `.address`.
2. Wires `agent-workflow-cli`'s test suite into CI by pointing the CI test step at `pnpm test:all` (= `pnpm test && pnpm test:cli`).

## Why

`agent-workflow-cli`'s vitest suite was invisible to CI: the job ran `pnpm test` (`test:dom && test:runtime && test:examples`), which has no cli lane. So the migration's two `.address.path` reads rotted silently — the address string IS the path now, so `.path` is `undefined`, and `host.resolve(byKey?.address.path ?? '')` resolved `''`; the `runtime-host` "resolves by key and by actor:// path" test would fail when actually run. This was the first casualty of the blind spot.

Switching CI to `pnpm test:all` closes the gap so shared-contract changes can't silently break the CLI again. CI's build step runs first, so the cli test's `@actor-web/runtime` dist resolves.

## Verification

- `pnpm test:cli` — **29 passed** (the migrated `runtime-host` test now exercises the branded address).
- `verify.sh --full` — **ALL PASSED**.

## Note (separable follow-up)

`agent-workflow-cli/tsconfig.json` excludes `**/*.test.ts` from typecheck, so the cli test files aren't type-checked anywhere. The vitest lane (now in CI) is the primary protection and catches runtime breaks like this one; typechecking the cli test files is a smaller separable improvement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the multi-process deployment guide’s remote actor example to use the current address format.

* **Chores**
  * Adjusted CI test execution to run the full test suite during validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->